### PR TITLE
feat(sourcepoint_unified_cmp): add event delegate to handle consent events (fixes: #6)

### DIFF
--- a/packages/sourcepoint_unified_cmp/example/lib/main.dart
+++ b/packages/sourcepoint_unified_cmp/example/lib/main.dart
@@ -40,22 +40,19 @@ class _SourcepointunifiedCMPBuilderExampleState
     );
 
     _controller = SourcepointController(config: config);
-    //onConsentUIReady: () {
-    //  debugPrint('onConsentUIReady');
-    //},
-    //onConsentUIFinished: () {
-    //  debugPrint('onConsentUIFinished');
-    //},
-    //onConsentReady: ({GDPRUserConsent? consent}) {
-    //  debugPrint('Consent string: ${consent?.consentString}');
-    //  debugPrint('Consent action is taken and returned to Sourcepoint');
-    //},
-    //onAction: (ActionType? action) {
-    //  debugPrint('onAction(${action.toString()})');
-    //},
-    //onError: (errorCode) {
-    //  debugPrint('consentError: errorCode:$errorCode');
-    //},
+    _controller.setEventDelegate(
+      SourcepointEventDelegate(
+        onConsentReady: (SPConsent consent) {
+          debugPrint('DELEGATE onConsentReady: Consent string: '
+              '${consent.gdpr?.euconsent}');
+        },
+        onSpFinished: (SPConsent consent) {
+          debugPrint(
+            'DELEGATE SpFinished: Consent string: ${consent.gdpr?.euconsent}',
+          );
+        },
+      ),
+    );
   }
 
   @override

--- a/packages/sourcepoint_unified_cmp/lib/sourcepoint_unified_cmp.dart
+++ b/packages/sourcepoint_unified_cmp/lib/sourcepoint_unified_cmp.dart
@@ -11,6 +11,12 @@ SourcepointUnifiedCmpPlatform get _platform =>
 class SourcepointController {
   SourcepointController({required this.config});
   final SPConfig config;
+  SourcepointEventDelegate? delegate;
+
+  // ignore: use_setters_to_change_properties
+  void setEventDelegate(SourcepointEventDelegate delegate) {
+    _platform.registerEventDelegate(delegate);
+  }
 
   /// Loading a Privacy Manager on demand
   /// consent chnages will propagated via controller
@@ -29,4 +35,36 @@ class SourcepointController {
     debugPrint('loadMessage');
     return _platform.loadMessage(config);
   }
+}
+
+class SourcepointEventDelegate implements SourcepointEventDelegatePlatform {
+  SourcepointEventDelegate({
+    this.onConsentReady,
+    this.onUIReady,
+    this.onAction,
+    this.onError,
+    this.onNoIntentActivitiesFound,
+    this.onSpFinished,
+    this.onUIFinished,
+  });
+  @override
+  final void Function(SPConsent)? onConsentReady;
+
+  @override
+  final void Function(int viewId, ConsentAction consentAction)? onAction;
+
+  @override
+  final void Function(SourcepointUnifiedCmpError error)? onError;
+
+  @override
+  final void Function(String url)? onNoIntentActivitiesFound;
+
+  @override
+  final void Function(SPConsent consent)? onSpFinished;
+
+  @override
+  final void Function(int viewId)? onUIFinished;
+
+  @override
+  final void Function(int viewId)? onUIReady;
 }

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
@@ -97,7 +97,10 @@ enum class HostAPIActionType(val raw: Int) {
   MSGCANCEL(3),
   CUSTOM(4),
   SAVEANDEXIT(5),
-  PMDISMISS(6);
+  PMDISMISS(6),
+  GETMSGERROR(7),
+  GETMESSAGENOTCALLED(8),
+  UNKNOWN(9);
 
   companion object {
     fun ofRaw(raw: Int): HostAPIActionType? {

--- a/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
@@ -55,6 +55,9 @@ enum HostAPIActionType {
   custom,
   saveAndExit,
   pmDismiss,
+  getMsgError,
+  getMessageNotCalled,
+  unknown,
 }
 
 enum HostAPISourcepointUnifiedCmpError {

--- a/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
@@ -18,6 +18,9 @@ enum HostAPIActionType {
   custom,
   saveAndExit,
   pmDismiss,
+  getMsgError,
+  getMessageNotCalled,
+  unknown,
 }
 
 enum HostAPISourcepointUnifiedCmpError {

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/sourcepoint_unified_cmp_platform_interface.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/sourcepoint_unified_cmp_platform_interface.dart
@@ -35,8 +35,32 @@ abstract class SourcepointUnifiedCmpPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  void registerEventDelegate(SourcepointEventDelegatePlatform delegate) {
+    throw UnimplementedError(
+        'registerEventDelegate() has not been implemented.');
+  }
+
   /// show privacy manager
   Future<SPConsent> loadMessage(SPConfig config) {
     throw UnimplementedError('loadMessage() has not been implemented.');
   }
+}
+
+abstract class SourcepointEventDelegatePlatform {
+  SourcepointEventDelegatePlatform({
+    this.onConsentReady,
+    this.onUIFinished,
+    this.onUIReady,
+    this.onError,
+    this.onAction,
+    this.onNoIntentActivitiesFound,
+    this.onSpFinished,
+  });
+  final void Function(SPConsent)? onConsentReady;
+  final void Function(int viewId)? onUIFinished;
+  final void Function(int viewId)? onUIReady;
+  final void Function(SourcepointUnifiedCmpError error)? onError;
+  final void Function(int viewId, ConsentAction consentAction)? onAction;
+  final void Function(String url)? onNoIntentActivitiesFound;
+  final void Function(SPConsent consent)? onSpFinished;
 }

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
@@ -141,3 +141,39 @@ class SPConsent {
     return 'SPConsent(gdpr: $gdpr, ccpa: $ccpa)';
   }
 }
+
+class ConsentAction {
+  ConsentAction({
+    required this.actionType,
+    required this.pubData,
+    required this.campaignType,
+    this.customActionId,
+  });
+  final ActionType actionType;
+  final Object pubData;
+  final CampaignType campaignType;
+  final String? customActionId;
+}
+
+enum ActionType {
+  showOptions,
+  rejectAll,
+  acceptAll,
+  msgCancel,
+  custom,
+  saveAndExit,
+  pmDismiss,
+  getMsgError,
+  getMessageNotCalled,
+  unknown,
+}
+
+enum SourcepointUnifiedCmpError {
+  invalidArgumentException,
+  missingPropertyException,
+  invalidConsentResponse,
+  noInternetConnectionException,
+  executionInTheWrongThreadException,
+  requestFailedException,
+  invalidRequestException
+}


### PR DESCRIPTION
This commit introduces a new event delegate to handle consent events. This delegate is registered in the SourcepointController and is used to handle events such as onConsentReady, onUIFinished, onUIReady, onError, onAction, onNoIntentActivitiesFound, and onSpFinished. This allows for more granular control and handling of these events in the application.

feat(sourcepoint_unified_cmp_android): implement event delegate in Android plugin

The Android plugin now implements the event delegate introduced in the previous commit. This allows the Android plugin to handle the consent events and pass them to the Flutter side.

feat(sourcepoint_unified_cmp_platform_interface): add ConsentAction and SourcepointUnifiedCmpError

This commit introduces two new types, ConsentAction and SourcepointUnifiedCmpError. ConsentAction represents an action taken by the user in the consent process, and SourcepointUnifiedCmpError represents an error that occurred during the consent process. These types are used in the event delegate to provide more information about the events.

refactor(sourcepoint_unified_cmp): refactor event handling code

This commit refactors the event handling code to use the new event delegate. This simplifies the code and makes it easier to handle the different events.

fix(sourcepoint_unified_cmp_android): fix mapping of ActionType and SourcepointUnifiedCmpError

This commit fixes the mapping of ActionType and SourcepointUnifiedCmpError in the Android plugin. The previous mapping was incorrect and caused errors when these types were used. The mapping is now correct and the types can be used without errors.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
