### PR TITLE
feat(sourcepoint_unified_cmp): add loadPrivacyManager method to load Privacy Manager on demand

### DIFF
--- a/packages/sourcepoint_unified_cmp/example/lib/main.dart
+++ b/packages/sourcepoint_unified_cmp/example/lib/main.dart
@@ -80,6 +80,17 @@ class _SourcepointunifiedCMPBuilderExampleState
                 padding: EdgeInsets.only(top: 16),
                 child: Text('Result: we got initial consent'),
               ),
+              Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: TextButton(
+                  onPressed: () {
+                    _controller.loadPrivacyManager(
+                      pmId: '122058',
+                    );
+                  },
+                  child: const Text('Load Privacy Manager'),
+                ),
+              ),
             ];
           } else if (snapshot.hasError) {
             children = <Widget>[

--- a/packages/sourcepoint_unified_cmp/lib/sourcepoint_unified_cmp.dart
+++ b/packages/sourcepoint_unified_cmp/lib/sourcepoint_unified_cmp.dart
@@ -35,6 +35,12 @@ class SourcepointController {
     MessageType messageType = MessageType.mobile,
   }) async {
     debugPrint('loadPrivacyManager');
+    return _platform.loadPrivacyManager(
+      pmId,
+      pmTab,
+      campaignType,
+      messageType,
+    );
   }
 
   /// Loading the First Layer Message

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcePointUnifiedCmpData.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcePointUnifiedCmpData.kt
@@ -10,6 +10,8 @@ import HostAPIGDPRPurposeGrants
 import HostAPIGranularState
 import HostAPIGranularStatus
 import HostAPIMessageLanguage
+import HostAPIMessageType
+import HostAPIPMTab
 import HostAPISPConsent
 import com.sourcepoint.cmplibrary.data.network.model.optimized.ConsentStatus
 import com.sourcepoint.cmplibrary.data.network.model.optimized.GranularState
@@ -17,8 +19,10 @@ import com.sourcepoint.cmplibrary.data.network.util.CampaignsEnv
 import com.sourcepoint.cmplibrary.exception.CampaignType
 import com.sourcepoint.cmplibrary.model.ConsentAction
 import com.sourcepoint.cmplibrary.model.MessageLanguage
+import com.sourcepoint.cmplibrary.model.PMTab
 import com.sourcepoint.cmplibrary.model.exposed.ActionType
 import com.sourcepoint.cmplibrary.model.exposed.GDPRPurposeGrants
+import com.sourcepoint.cmplibrary.model.exposed.MessageType
 import com.sourcepoint.cmplibrary.model.exposed.SPConsents
 import com.sourcepoint.cmplibrary.model.exposed.SPGDPRConsent
 import io.flutter.Log
@@ -108,4 +112,19 @@ fun HostAPIMessageLanguage.toMessageLanguage() = when (this) {
 fun HostAPICampaignsEnv.toCampaignsEnv() = when (this) {
     HostAPICampaignsEnv.PUBLIC -> CampaignsEnv.PUBLIC
     HostAPICampaignsEnv.STAGE -> CampaignsEnv.STAGE
+}
+
+fun HostAPIPMTab.toPMTab() = when (this) {
+    HostAPIPMTab.PURPOSES -> PMTab.PURPOSES
+}
+
+fun HostAPICampaignType.toCampaignType() = when (this) {
+    HostAPICampaignType.CCPA -> CampaignType.CCPA
+    HostAPICampaignType.GDPR -> CampaignType.GDPR
+}
+
+fun HostAPIMessageType.toMessageType() = when (this) {
+    HostAPIMessageType.MOBILE -> MessageType.MOBILE
+    HostAPIMessageType.OTT -> MessageType.OTT
+    HostAPIMessageType.LAGACYOTT -> MessageType.LEGACY_OTT
 }

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
@@ -66,13 +66,13 @@ enum class HostAPICampaignType(val raw: Int) {
   }
 }
 
-enum class MessageType(val raw: Int) {
+enum class HostAPIMessageType(val raw: Int) {
   MOBILE(0),
   OTT(1),
-  LAGAZYOTT(2);
+  LAGACYOTT(2);
 
   companion object {
-    fun ofRaw(raw: Int): MessageType? {
+    fun ofRaw(raw: Int): HostAPIMessageType? {
       return values().firstOrNull { it.raw == raw }
     }
   }
@@ -454,6 +454,7 @@ private object SourcepointUnifiedCmpHostApiCodec : StandardMessageCodec() {
 /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
 interface SourcepointUnifiedCmpHostApi {
   fun loadMessage(accountId: Long, propertyId: Long, propertyName: String, pmId: String, messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv, messageTimeout: Long, runGDPRCampaign: Boolean, runCCPACampaign: Boolean, callback: (Result<HostAPISPConsent>) -> Unit)
+  fun loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType, messageType: HostAPIMessageType, callback: (Result<Unit>) -> Unit)
 
   companion object {
     /** The codec used by SourcepointUnifiedCmpHostApi. */
@@ -484,6 +485,28 @@ interface SourcepointUnifiedCmpHostApi {
               } else {
                 val data = result.getOrNull()
                 reply.reply(wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadPrivacyManager", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val pmIdArg = args[0] as String
+            val pmTabArg = HostAPIPMTab.ofRaw(args[1] as Int)!!
+            val campaignTypeArg = HostAPICampaignType.ofRaw(args[2] as Int)!!
+            val messageTypeArg = HostAPIMessageType.ofRaw(args[3] as Int)!!
+            api.loadPrivacyManager(pmIdArg, pmTabArg, campaignTypeArg, messageTypeArg) { result: Result<Unit> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(wrapError(error))
+              } else {
+                reply.reply(wrapResult(null))
               }
             }
           }

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmpPlugin.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmpPlugin.kt
@@ -1,8 +1,11 @@
 package de.thekorn.sourcepoint.unified.cmp
 
 
+import HostAPICampaignType
 import HostAPICampaignsEnv
 import HostAPIMessageLanguage
+import HostAPIMessageType
+import HostAPIPMTab
 import HostAPISPConsent
 import SourcepointUnifiedCmpFlutterApi
 import SourcepointUnifiedCmpHostApi
@@ -203,6 +206,21 @@ class SourcepointUnifiedCmpPlugin : FlutterPlugin, ActivityAware, SourcepointUni
         spClient.isInitialized.invokeOnCompletion {
             callback(Result.success(spClient.isInitialized.getCompleted()))
         }
+    }
+
+    override fun loadPrivacyManager(
+        pmId: String,
+        pmTab: HostAPIPMTab,
+        campaignType: HostAPICampaignType,
+        messageType: HostAPIMessageType,
+        callback: (Result<Unit>) -> Unit
+    ) {
+        spConsentLib?.loadPrivacyManager(
+            pmId,
+            pmTab.toPMTab(),
+            campaignType.toCampaignType(),
+            messageType.toMessageType()
+        )
     }
 
 }

--- a/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
@@ -195,6 +195,39 @@ extension on messages.HostAPISPConsent {
   }
 }
 
+extension on PMTab {
+  messages.HostAPIPMTab toHostAPIPMTab() {
+    switch (this) {
+      case PMTab.purposes:
+        return messages.HostAPIPMTab.purposes;
+    }
+  }
+}
+
+extension on CampaignType {
+  messages.HostAPICampaignType toHostAPICampaignType() {
+    switch (this) {
+      case CampaignType.gdpr:
+        return messages.HostAPICampaignType.gdpr;
+      case CampaignType.ccpa:
+        return messages.HostAPICampaignType.ccpa;
+    }
+  }
+}
+
+extension on MessageType {
+  messages.HostAPIMessageType toHostAPIMessageType() {
+    switch (this) {
+      case MessageType.mobile:
+        return messages.HostAPIMessageType.mobile;
+      case MessageType.lagacyOtt:
+        return messages.HostAPIMessageType.lagacyOtt;
+      case MessageType.ott:
+        return messages.HostAPIMessageType.ott;
+    }
+  }
+}
+
 /// The Android implementation of [SourcepointUnifiedCmpPlatform].
 class SourcepointUnifiedCmpAndroid extends SourcepointUnifiedCmpPlatform {
   final messages.SourcepointUnifiedCmpHostApi _api =
@@ -229,6 +262,21 @@ class SourcepointUnifiedCmpAndroid extends SourcepointUnifiedCmpPlatform {
     );
     final consent = hostConsent.toSPConsent();
     return consent;
+  }
+
+  @override
+  Future<void> loadPrivacyManager(
+    String pmId,
+    PMTab pmTab,
+    CampaignType campaignType,
+    MessageType messageType,
+  ) async {
+    await _api.loadPrivacyManager(
+      pmId: pmId,
+      pmTab: pmTab.toHostAPIPMTab(),
+      campaignType: campaignType.toHostAPICampaignType(),
+      messageType: messageType.toHostAPIMessageType(),
+    );
   }
 }
 

--- a/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
@@ -35,10 +35,10 @@ enum HostAPICampaignType {
   ccpa,
 }
 
-enum MessageType {
+enum HostAPIMessageType {
   mobile,
   ott,
-  lagazyOtt,
+  lagacyOtt,
 }
 
 enum HostAPIGranularState {
@@ -493,6 +493,36 @@ class SourcepointUnifiedCmpHostApi {
       );
     } else {
       return (__pigeon_replyList[0] as HostAPISPConsent?)!;
+    }
+  }
+
+  Future<void> loadPrivacyManager({
+    required String pmId,
+    required HostAPIPMTab pmTab,
+    required HostAPICampaignType campaignType,
+    required HostAPIMessageType messageType,
+  }) async {
+    const String __pigeon_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadPrivacyManager';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel.send(
+            <Object?>[pmId, pmTab.index, campaignType.index, messageType.index])
+        as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
     }
   }
 }

--- a/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
@@ -6,7 +6,7 @@ enum HostAPIPMTab { purposes }
 
 enum HostAPICampaignType { gdpr, ccpa }
 
-enum MessageType { mobile, ott, lagazyOtt }
+enum HostAPIMessageType { mobile, ott, lagacyOtt }
 
 enum HostAPIGranularState { all, some, none }
 
@@ -187,6 +187,14 @@ abstract class SourcepointUnifiedCmpHostApi {
     required int messageTimeout,
     required bool runGDPRCampaign,
     required bool runCCPACampaign,
+  });
+
+  @async
+  void loadPrivacyManager({
+    required String pmId,
+    required HostAPIPMTab pmTab,
+    required HostAPICampaignType campaignType,
+    required HostAPIMessageType messageType,
   });
 }
 

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/sourcepoint_unified_cmp_platform_interface.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/sourcepoint_unified_cmp_platform_interface.dart
@@ -58,6 +58,16 @@ abstract class SourcepointUnifiedCmpPlatform extends PlatformInterface {
   Future<SPConsent> loadMessage(SPConfig config) {
     throw UnimplementedError('loadMessage() has not been implemented.');
   }
+
+  /// Loading a Privacy Manager on demand
+  Future<void> loadPrivacyManager(
+    String pmId,
+    PMTab pmTab,
+    CampaignType campaignType,
+    MessageType messageType,
+  ) {
+    throw UnimplementedError('loadPrivacyManager() has not been implemented.');
+  }
 }
 
 /// Represents the platform interface for handling Sourcepoint event delegates.

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/method_channel_sourcepoint_unified_cmp.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/method_channel_sourcepoint_unified_cmp.dart
@@ -14,4 +14,14 @@ class MethodChannelSourcepointUnifiedCmp extends SourcepointUnifiedCmpPlatform {
     return (await methodChannel.invokeMethod<SPConsent>('loadMessage')) ??
         SPConsent();
   }
+
+  @override
+  Future<void> loadPrivacyManager(
+    String pmId,
+    PMTab pmTab,
+    CampaignType campaignType,
+    MessageType messageType,
+  ) async {
+    await methodChannel.invokeMethod<SPConsent>('loadPrivacyManager');
+  }
 }

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
@@ -35,7 +35,7 @@ enum PMTab { purposes }
 
 enum CampaignType { gdpr, ccpa }
 
-enum MessageType { mobile, ott, lagazyOtt }
+enum MessageType { mobile, ott, lagacyOtt }
 
 enum GranularState { all, some, none }
 


### PR DESCRIPTION

This change allows the Privacy Manager to be loaded on demand, providing more flexibility and control over the privacy settings. The method takes parameters for pmId, pmTab, campaignType, and messageType to customize the Privacy Manager according to the user's needs.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
