### PR TITLE
fix: iOS SourcepointUnifiedCmpData.swift - map ShowPrivacyManager to showOptions

### DIFF
--- a/packages/sourcepoint_unified_cmp_ios/ios/Classes/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/Classes/SourcepointUnifiedCmpData.swift
@@ -126,6 +126,11 @@ extension SPCampaignType {
   }
 }
 
+
+// FIXME(thekorn) the anddroid and the ios sdk are actually diverging here.
+//   ios is using newer and more granular action types, whereas
+//   android is still using the old ones
+//   once android is catching up we need to unify
 extension SPActionType {
   func toHostAPIActionType() throws -> HostAPIActionType {
     switch self {
@@ -138,7 +143,7 @@ extension SPActionType {
     case .AcceptAll:
       HostAPIActionType.acceptAll
     case .ShowPrivacyManager:
-      throw NotImplementedError.notImplemented
+        HostAPIActionType.showOptions
     case .RejectAll:
       HostAPIActionType.rejectAll
     case .Dismiss:


### PR DESCRIPTION
🔧 refactor(SourcepointUnifiedCmpData.swift): replace NotImplementedError with HostAPIActionType.showOptions in SPActionType extension to align with iOS SDK's granular action types 📝 docs(SourcepointUnifiedCmpData.swift): add FIXME comment to highlight divergence between iOS and Android SDKs and the need for unification

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
