### PR TITLE
fix: controller.dart): Refactor delegate type from SourcepointEventDelegate to SourcepointEventDelegatePlatform for better platform-specific handling of events.

### DIFF
--- a/packages/sourcepoint_unified_cmp/lib/src/controller.dart
+++ b/packages/sourcepoint_unified_cmp/lib/src/controller.dart
@@ -17,10 +17,10 @@ class SourcepointController {
   final SPConfig config;
 
   /// The delegate for handling Sourcepoint events in the Sourcepoint
-  SourcepointEventDelegate? delegate;
+  SourcepointEventDelegatePlatform? delegate;
 
   /// Registers the [delegate] as the event delegate for the Sourcepoint
-  void setEventDelegate(SourcepointEventDelegate delegate) {
+  void setEventDelegate(SourcepointEventDelegatePlatform delegate) {
     _platform.registerEventDelegate(delegate);
   }
 


### PR DESCRIPTION
use abstract argument in setEventDelegate

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
