### PR TITLE
feat: the sourcepoint controller is now notifying observers when the consent is ready

### DIFF
--- a/packages/sourcepoint_unified_cmp/example/lib/main.dart
+++ b/packages/sourcepoint_unified_cmp/example/lib/main.dart
@@ -59,7 +59,11 @@ class _SourcepointUnifiedCMPBuilderExampleState
             );
           },
         ),
-      );
+      )
+      ..addListener(() {
+        debugPrint('CONSENT CHANGE NOTIFIER: Consent string: '
+            '${_controller.consent?.gdpr?.euconsent}');
+      });
   }
 
   @override

--- a/packages/sourcepoint_unified_cmp/lib/src/controller.dart
+++ b/packages/sourcepoint_unified_cmp/lib/src/controller.dart
@@ -5,13 +5,15 @@ SourcepointUnifiedCmpPlatform get _platform =>
     SourcepointUnifiedCmpPlatform.instance;
 
 /// A controller for managing Sourcepoint functionality.
-class SourcepointController {
+class SourcepointController extends ConsentChangeNotifier {
   /// A controller for managing Sourcepoint consent management platform.
   ///
   /// The [SourcepointController] is responsible for handling the configuration
   /// and management of the Sourcepoint consent management platform.
   /// It requires a [config] parameter to be provided during initialization.
-  SourcepointController({required this.config});
+  SourcepointController({required this.config}) {
+    _platform.registerConsentChangeNotifier(this);
+  }
 
   /// The configuration for the Sourcepoint consent management platform.
   final SPConfig config;

--- a/packages/sourcepoint_unified_cmp/lib/src/controller.dart
+++ b/packages/sourcepoint_unified_cmp/lib/src/controller.dart
@@ -16,12 +16,16 @@ class SourcepointController {
   /// The configuration for the Sourcepoint consent management platform.
   final SPConfig config;
 
-  /// The delegate for handling Sourcepoint events in the Sourcepoint
-  SourcepointEventDelegatePlatform? delegate;
+  SourcepointEventDelegatePlatform? _delegate;
 
   /// Registers the [delegate] as the event delegate for the Sourcepoint
   void setEventDelegate(SourcepointEventDelegatePlatform delegate) {
+    assert(
+      _delegate == null,
+      'EventDelegate already set, you can only have one delegate at a time.',
+    );
     _platform.registerEventDelegate(delegate);
+    _delegate = delegate;
   }
 
   /// Loading a Privacy Manager on demand

--- a/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
@@ -222,6 +222,7 @@ extension on MessageType {
 class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
   final messages.SourcepointUnifiedCmpHostApi _api =
       messages.SourcepointUnifiedCmpHostApi();
+  ConsentChangeNotifier? _notifier;
 
   /// Registers this class as the default instance
   /// of [SourcepointUnifiedCmpPlatform]
@@ -232,7 +233,10 @@ class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
   @override
   void registerEventDelegate(SourcepointEventDelegatePlatform delegate) {
     messages.SourcepointUnifiedCmpFlutterApi.setup(
-      SourcepointEventHandler(delegate: delegate),
+      SourcepointEventHandler(
+        delegate: delegate,
+        consentChangeNotifier: _notifier,
+      ),
     );
   }
 
@@ -269,6 +273,12 @@ class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
       messageType: messageType.toHostAPIMessageType(),
     );
   }
+
+  @override
+  void registerConsentChangeNotifier(ConsentChangeNotifier notifier) {
+    assert(_notifier == null, 'ConsentChangeNotifier already set');
+    _notifier = notifier;
+  }
 }
 
 /// This class represents the event handler for Sourcepoint in the Android
@@ -280,61 +290,53 @@ class SourcepointEventHandler
   /// This class is responsible for handling events related to Sourcepoint.
   /// It requires a [delegate] parameter, which is an object that implements the
   /// necessary methods to handle the events.
-  SourcepointEventHandler({required this.delegate});
+  SourcepointEventHandler({
+    required this.delegate,
+    ConsentChangeNotifier? consentChangeNotifier,
+  }) : _consentChangeNotifier = consentChangeNotifier;
 
   /// The delegate for handling Sourcepoint events in the Sourcepoint
   /// Unified CMP Android library.
   final SourcepointEventDelegatePlatform delegate;
+  final ConsentChangeNotifier? _consentChangeNotifier;
 
   @override
   void onAction(String viewId, messages.HostAPIConsentAction consentAction) {
-    if (delegate.onAction != null) {
-      // FIXME: generalize android=int, ios=string
-      delegate.onAction?.call(0, consentAction.toConsentAction());
-    }
+    // FIXME: generalize android=int, ios=string
+    delegate.onAction?.call(0, consentAction.toConsentAction());
   }
 
   @override
   void onConsentReady(messages.HostAPISPConsent consent) {
-    if (delegate.onConsentReady != null) {
-      delegate.onConsentReady?.call(consent.toSPConsent());
-    }
+    delegate.onConsentReady?.call(consent.toSPConsent());
+    // Also notify the consent change notifier about the new consent
+    _consentChangeNotifier?.updateConsent(consent.toSPConsent());
   }
 
   @override
   void onError(messages.HostAPISPError error) {
-    if (delegate.onError != null) {
-      delegate.onError?.call(error.toSPError());
-    }
+    delegate.onError?.call(error.toSPError());
   }
 
   @override
   void onNoIntentActivitiesFound(String url) {
-    if (delegate.onNoIntentActivitiesFound != null) {
-      delegate.onNoIntentActivitiesFound?.call(url);
-    }
+    delegate.onNoIntentActivitiesFound?.call(url);
   }
 
   @override
   void onSpFinished(messages.HostAPISPConsent consent) {
-    if (delegate.onSpFinished != null) {
-      delegate.onSpFinished?.call(consent.toSPConsent());
-    }
+    delegate.onSpFinished?.call(consent.toSPConsent());
   }
 
   @override
   void onUIFinished(String viewId) {
-    if (delegate.onUIFinished != null) {
-      // FIXME: generalize android=int, ios=string
-      delegate.onUIFinished?.call(0);
-    }
+    // FIXME: generalize android=int, ios=string
+    delegate.onUIFinished?.call(0);
   }
 
   @override
   void onUIReady(String viewId) {
-    if (delegate.onUIReady != null) {
-      // FIXME: generalize android=int, ios=string
-      delegate.onUIReady?.call(0);
-    }
+    // FIXME: generalize android=int, ios=string
+    delegate.onUIReady?.call(0);
   }
 }

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/sourcepoint_unified_cmp_platform_interface.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/sourcepoint_unified_cmp_platform_interface.dart
@@ -1,2 +1,3 @@
+export 'src/change_notifier.dart';
 export 'src/interface.dart';
 export 'src/types.dart';

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/change_notifier.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/change_notifier.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/foundation.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/sourcepoint_unified_cmp_platform_interface.dart';
+
+/// A class that extends [ChangeNotifier] and provides a way to notify listeners
+/// when the consent changes.
+/// This is triggered by the platform implementation when the consent is ready.
+class ConsentChangeNotifier extends ChangeNotifier {
+  /// Represents the consent for Sourcepoint Unified CMP.
+  SPConsent? consent;
+
+  /// Updates the consent with the provided [newConsent].
+  ///
+  /// This method is used to update the consent with the new consent information
+  /// provided in the [newConsent] parameter.
+  /// ```
+  void updateConsent(SPConsent newConsent) {
+    consent = newConsent;
+    notifyListeners();
+  }
+}

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/interface.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/interface.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/src/change_notifier.dart';
 import 'package:sourcepoint_unified_cmp_platform_interface/src/method_channel.dart';
 import 'package:sourcepoint_unified_cmp_platform_interface/src/types.dart';
 
@@ -56,6 +57,18 @@ abstract class SourcepointUnifiedCmpPlatform extends PlatformInterface {
   void registerEventDelegate(SourcepointEventDelegatePlatform delegate) {
     throw UnimplementedError(
       'registerEventDelegate() has not been implemented.',
+    );
+  }
+
+  /// Registers a [ConsentChangeNotifier] to receive notifications when the
+  /// consent changes.
+  ///
+  /// The [notifier] parameter is the [ConsentChangeNotifier] instance that
+  /// will be registered. When the consent changes, the
+  /// [ConsentChangeNotifier]'s listeners will be notified.
+  void registerConsentChangeNotifier(ConsentChangeNotifier notifier) {
+    throw UnimplementedError(
+      'registerConsentChangeNotifier() has not been implemented.',
     );
   }
 


### PR DESCRIPTION
this includes a breaking change: event delegates are not silently overwritten anymore, assertion is raised

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
