### PR TITLE
fix: support consent change notifier without a event delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,19 +60,19 @@ Packages with other changes:
 
 #### `sourcepoint_unified_cmp` - `v0.1.11+2`
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 #### `sourcepoint_unified_cmp_android` - `v0.1.11+2`
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 #### `sourcepoint_unified_cmp_ios` - `v0.1.11+2`
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 #### `sourcepoint_unified_cmp_platform_interface` - `v0.1.11+2`
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 
 ## 2024-03-30

--- a/packages/sourcepoint_unified_cmp/CHANGELOG.md
+++ b/packages/sourcepoint_unified_cmp/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.1.11+2
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 ## 0.1.11+1
 

--- a/packages/sourcepoint_unified_cmp/lib/src/controller.dart
+++ b/packages/sourcepoint_unified_cmp/lib/src/controller.dart
@@ -18,16 +18,9 @@ class SourcepointController extends ConsentChangeNotifier {
   /// The configuration for the Sourcepoint consent management platform.
   final SPConfig config;
 
-  SourcepointEventDelegatePlatform? _delegate;
-
   /// Registers the [delegate] as the event delegate for the Sourcepoint
   void setEventDelegate(SourcepointEventDelegatePlatform delegate) {
-    assert(
-      _delegate == null,
-      'EventDelegate already set, you can only have one delegate at a time.',
-    );
     _platform.registerEventDelegate(delegate);
-    _delegate = delegate;
   }
 
   /// Loading a Privacy Manager on demand

--- a/packages/sourcepoint_unified_cmp_android/CHANGELOG.md
+++ b/packages/sourcepoint_unified_cmp_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.1.11+2
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 ## 0.1.11+1
 

--- a/packages/sourcepoint_unified_cmp_ios/CHANGELOG.md
+++ b/packages/sourcepoint_unified_cmp_ios/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.1.11+2
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 ## 0.1.11+1
 

--- a/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
@@ -223,6 +223,7 @@ class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
   final messages.SourcepointUnifiedCmpHostApi _api =
       messages.SourcepointUnifiedCmpHostApi();
   ConsentChangeNotifier? _notifier;
+  SourcepointEventDelegatePlatform? _delegate;
 
   /// Registers this class as the default instance
   /// of [SourcepointUnifiedCmpPlatform]
@@ -232,12 +233,17 @@ class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
 
   @override
   void registerEventDelegate(SourcepointEventDelegatePlatform delegate) {
+    assert(
+      _delegate == null,
+      'EventDelegate already set, you can only have one delegate at a time.',
+    );
     messages.SourcepointUnifiedCmpFlutterApi.setup(
       SourcepointEventHandler(
         delegate: delegate,
         consentChangeNotifier: _notifier,
       ),
     );
+    _delegate = delegate;
   }
 
   @override
@@ -277,6 +283,12 @@ class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
   @override
   void registerConsentChangeNotifier(ConsentChangeNotifier notifier) {
     assert(_notifier == null, 'ConsentChangeNotifier already set');
+    messages.SourcepointUnifiedCmpFlutterApi.setup(
+      SourcepointEventHandler(
+        delegate: _delegate,
+        consentChangeNotifier: notifier,
+      ),
+    );
     _notifier = notifier;
   }
 }
@@ -291,52 +303,53 @@ class SourcepointEventHandler
   /// It requires a [delegate] parameter, which is an object that implements the
   /// necessary methods to handle the events.
   SourcepointEventHandler({
-    required this.delegate,
+    SourcepointEventDelegatePlatform? delegate,
     ConsentChangeNotifier? consentChangeNotifier,
-  }) : _consentChangeNotifier = consentChangeNotifier;
+  })  : _consentChangeNotifier = consentChangeNotifier,
+        _delegate = delegate;
 
   /// The delegate for handling Sourcepoint events in the Sourcepoint
   /// Unified CMP Android library.
-  final SourcepointEventDelegatePlatform delegate;
+  final SourcepointEventDelegatePlatform? _delegate;
   final ConsentChangeNotifier? _consentChangeNotifier;
 
   @override
   void onAction(String viewId, messages.HostAPIConsentAction consentAction) {
     // FIXME: generalize android=int, ios=string
-    delegate.onAction?.call(0, consentAction.toConsentAction());
+    _delegate?.onAction?.call(0, consentAction.toConsentAction());
   }
 
   @override
   void onConsentReady(messages.HostAPISPConsent consent) {
-    delegate.onConsentReady?.call(consent.toSPConsent());
+    _delegate?.onConsentReady?.call(consent.toSPConsent());
     // Also notify the consent change notifier about the new consent
     _consentChangeNotifier?.updateConsent(consent.toSPConsent());
   }
 
   @override
   void onError(messages.HostAPISPError error) {
-    delegate.onError?.call(error.toSPError());
+    _delegate?.onError?.call(error.toSPError());
   }
 
   @override
   void onNoIntentActivitiesFound(String url) {
-    delegate.onNoIntentActivitiesFound?.call(url);
+    _delegate?.onNoIntentActivitiesFound?.call(url);
   }
 
   @override
   void onSpFinished(messages.HostAPISPConsent consent) {
-    delegate.onSpFinished?.call(consent.toSPConsent());
+    _delegate?.onSpFinished?.call(consent.toSPConsent());
   }
 
   @override
   void onUIFinished(String viewId) {
     // FIXME: generalize android=int, ios=string
-    delegate.onUIFinished?.call(0);
+    _delegate?.onUIFinished?.call(0);
   }
 
   @override
   void onUIReady(String viewId) {
     // FIXME: generalize android=int, ios=string
-    delegate.onUIReady?.call(0);
+    _delegate?.onUIReady?.call(0);
   }
 }

--- a/packages/sourcepoint_unified_cmp_platform_interface/CHANGELOG.md
+++ b/packages/sourcepoint_unified_cmp_platform_interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.1.11+2
 
- - **FEAT**: SourcepointControler - its now a `ChangeNotifier` for SPConsent.
+ - **FEAT**: SourcepointController - its now a `ChangeNotifier` for SPConsent.
 
 ## 0.1.11+1
 


### PR DESCRIPTION
♻️ (controller.dart): Remove _delegate from SourcepointController toavoid redundancy
♻️ (sourcepoint_unified_cmp_android.dart, sourcepoint_unified_cmp_ios.dart): Add _delegate to SourcepointUnifiedCmpAndroid and SourcepointUnifiedCmpIOS to handle event delegation
✨ (sourcepoint_unified_cmp_android.dart, sourcepoint_unified_cmp_ios.dart): Add assertion to ensure only one delegate can be set at a time
✨ (sourcepoint_unified_cmp_android.dart, sourcepoint_unified_cmp_ios.dart): Add setup for SourcepointEventHandler in registerConsentChangeNotifier method to handle consent changes
♻️ (sourcepoint_unified_cmp_android.dart, sourcepoint_unified_cmp_ios.dart): Change delegate in SourcepointEventHandler to optional and use null safety when calling delegate methods

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
