### PR TITLE
feat: Upgrade ConsentViewController dependency from 7.6.6 to 7.6.8 for better performance and bug fixes

### DIFF
--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios.podspec
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://github.com/thekorn/sourcepoint_unified_cmp'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Markus Korn' => 'markus.korn@gmail.com' }
-  s.source           = { :path => '.' }  
+  s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'ConsentViewController', '7.6.6'
+  s.dependency 'ConsentViewController', '7.6.8'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION


## Description

iOS ConsentViewController update to 7.6.8

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
