### PR TITLE
fix(ios): handle unsupported campaign types gracefully instead of crashing

### DIFF
--- a/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
@@ -201,6 +201,10 @@ extension on CampaignType {
         return messages.HostAPICampaignType.ccpa;
       case CampaignType.usnat:
         return messages.HostAPICampaignType.usnat;
+      case CampaignType.unknown:
+        throw UnimplementedError(
+          'CampaignType.unknown is iOS-only and cannot be used on Android.',
+        );
     }
   }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/Classes/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/Classes/SourcepointUnifiedCmpData.swift
@@ -118,24 +118,25 @@ extension HostAPIPMTab {
 extension SPAction {
   func toHostAPIConsentAction() -> HostAPIConsentAction {
     HostAPIConsentAction(
-      actionType: try! type.toHostAPIActionType(),
+      actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
       pubData: String(describing: publisherData),
-      campaignType: try! campaignType.toHostAPICampaignType(),
+      campaignType: campaignType.toHostAPICampaignType(),
       customActionId: customActionId
     )
   }
 }
 
 extension SPCampaignType {
-  func toHostAPICampaignType() throws -> HostAPICampaignType {
+  func toHostAPICampaignType() -> HostAPICampaignType {
     switch self {
     case .ccpa:
-      HostAPICampaignType.ccpa
+      return HostAPICampaignType.ccpa
     case .gdpr:
-      HostAPICampaignType.gdpr
+      return HostAPICampaignType.gdpr
     default:
-      // NOTE: there is no support for all other campaign types
-      throw NotImplementedError.notImplemented
+      // NOTE: .unknown, .usnat, .ios14 and other campaign types are not fully
+      // supported yet, map them to .unknown to avoid crashing
+      return HostAPICampaignType.unknown
     }
   }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/Classes/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/Classes/SourcepointUnifiedCmpPlugin.swift
@@ -43,6 +43,8 @@ public class SourcepointUnifiedCmpPlugin: UIViewController, FlutterPlugin,
       consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
     case HostAPICampaignType.ccpa:
       consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    case HostAPICampaignType.unknown:
+      break
     }
   }
 

--- a/packages/sourcepoint_unified_cmp_ios/ios/Classes/pigeons/SourcepointUnifiedCmp.g.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/Classes/pigeons/SourcepointUnifiedCmp.g.swift
@@ -142,6 +142,7 @@ enum HostAPIPMTab: Int {
 enum HostAPICampaignType: Int {
   case gdpr = 0
   case ccpa = 1
+  case unknown = 2
 }
 
 enum HostAPIMessageType: Int {

--- a/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
@@ -55,6 +55,8 @@ extension on messages.HostAPICampaignType {
         return CampaignType.gdpr;
       case messages.HostAPICampaignType.ccpa:
         return CampaignType.ccpa;
+      case messages.HostAPICampaignType.unknown:
+        return CampaignType.unknown;
     }
   }
 }
@@ -204,6 +206,8 @@ extension on CampaignType {
       case CampaignType.usnat:
         // FIXME: Handle this case.
         throw UnimplementedError();
+      case CampaignType.unknown:
+        return messages.HostAPICampaignType.unknown;
     }
   }
 }

--- a/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
@@ -49,7 +49,7 @@ bool _deepEquals(Object? a, Object? b) {
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa }
+enum HostAPICampaignType { gdpr, ccpa, unknown }
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
@@ -4,7 +4,7 @@ import 'package:pigeon/pigeon.dart';
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa }
+enum HostAPICampaignType { gdpr, ccpa, unknown }
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
@@ -108,6 +108,10 @@ enum CampaignType {
   /// mobile devices. Click here to learn more about implementing U.S.
   /// Multi-State Privacy on OTT.
   ///usnat
+
+  /// Unknown campaign type - used when the campaign type is not recognized
+  /// (e.g. ios14 or other iOS-specific campaign types)
+  unknown,
   // TODO(thekorn): add missing iOs specific campaigns
 }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Prevents a crash on iOS when the Sourcepoint SDK returns an unrecognized campaign type by replacing force-try (try!) calls with safe alternatives and introducing an unknown fallback.

Resolves #259 when user taps on the cancel button, which causes the app to crash on iOS.

<img width="300" alt="Screenshot 2026-04-04 at 00 00 26" src="https://github.com/user-attachments/assets/c7216d40-9739-429d-bc4a-a2ab2cfcabef" />


Resolves 
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
