### PR TITLE
fix(ios): migrate example apps to UIScene lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Flutter federated plugin (Melos monorepo) wrapping the Sourcepoint CMP SDKs for 
 - All tests + coverage + cspell: `melos run test:all` · Per-package tests: `melos run test`
 - Single test: `cd packages/<pkg> && fvm flutter test test/path/to_foo_test.dart --plain-name "name"`
 - Codegen: `melos run generate:pigeon:all`, `melos run generate:mocks:all`
-- Run example app: `melos run run:example -- -d <device>` (variants: `run:example:flutter_webview`, `run:example:flutter_inappwebview`)
+- Run example app: `melos run run:example -- -d <device>` (variants: `run:example:spm`, `run:example:flutter_webview`, `run:example:flutter_inappwebview`)
 - Coverage gate: `melos run check-coverage` (≥20%, generated `*.g.dart` excluded)
 
 ## Style
@@ -23,4 +23,3 @@ Flutter federated plugin (Melos monorepo) wrapping the Sourcepoint CMP SDKs for 
 - Swift: `swiftformat .` (see `.swiftformat`). Kotlin: `ktlint --format` (skip `**/*.g.kt`).
 - Errors: surface via Pigeon `FlutterError` from native; on Dart side use typed exceptions and `Result`-style returns where present—don’t swallow errors.
 - Commit hygiene: keep changelogs per-package (Melos manages versioning); don’t hand-bump versions.
-

--- a/packages/sourcepoint_unified_cmp/example/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp/example/ios/Runner/AppDelegate.swift
@@ -7,7 +7,6 @@ import UIKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 

--- a/packages/sourcepoint_unified_cmp/example/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,16 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/packages/sourcepoint_unified_cmp/example/ios/Runner/Info.plist
+++ b/packages/sourcepoint_unified_cmp/example/ios/Runner/Info.plist
@@ -26,6 +26,27 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/packages/sourcepoint_unified_cmp/example_spm/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp/example_spm/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/packages/sourcepoint_unified_cmp/example_spm/ios/Runner/Info.plist
+++ b/packages/sourcepoint_unified_cmp/example_spm/ios/Runner/Info.plist
@@ -26,6 +26,27 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios/Runner/AppDelegate.swift
@@ -7,7 +7,6 @@ import UIKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 

--- a/packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,16 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios/Runner/Info.plist
+++ b/packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios/Runner/Info.plist
@@ -26,6 +26,27 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				3DFE44B523C32FAD2B15BF96 /* [CP] Copy Pods Resources */,
+				47909F6C918AD79B49C329E2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -261,6 +262,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		47909F6C918AD79B49C329E2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {

--- a/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner/AppDelegate.swift
@@ -7,7 +7,6 @@ import UIKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 

--- a/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner/AppDelegate.swift
+++ b/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,16 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
     override func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+        GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
     }
 }

--- a/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner/Info.plist
+++ b/packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios/Runner/Info.plist
@@ -26,6 +26,27 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>


### PR DESCRIPTION
Closes #331

Migrates the iOS runners of the three example apps to the UIScene
lifecycle, following the [Flutter migration guide](https://flutter.dev/to/uiscene-migration).

## Changes
- Each `AppDelegate.swift` now adopts `FlutterImplicitEngineDelegate`
  and implements `didInitializeImplicitFlutterEngine` so plugins are
  registered correctly with the implicit Flutter engine under the new
  launch order.
- Each `Info.plist` gains a `UIApplicationSceneManifest` entry
  configured with `UIWindowScene` + `FlutterSceneDelegate` (single
  scene, no multi-scene support).

Affected apps:
- `packages/sourcepoint_unified_cmp/example/ios`
- `packages/sourcepoint_unified_cmp_flutter_webview_extension/example/ios`
- `packages/sourcepoint_unified_cmp_flutter_inappwebview_extension/example/ios`

## Verification
- `plutil -lint` passes on all three `Info.plist` files.
- `melos run analyze`: No issues found.
- `melos run test --no-select`: all package tests pass.
- `melos run test:all` itself fails in the pre-existing `merge-trace-files`
  step (coverde `--no-dry-run` option mismatch); unrelated to this change.