### PR TITLE
feat: customConsentGdpr / deleteCustomConsentGdpr integration

### DIFF
--- a/packages/sourcepoint_unified_cmp/lib/src/controller.dart
+++ b/packages/sourcepoint_unified_cmp/lib/src/controller.dart
@@ -46,4 +46,44 @@ class SourcepointController extends ConsentChangeNotifier
     debugPrint('loadMessage');
     return _platform.loadMessage(config);
   }
+
+  /// Programmatically grant custom GDPR consent to the supplied [vendors],
+  /// [categories] and [legIntCategories].
+  ///
+  /// The native SDK persists the consent locally and the registered
+  /// [ConsentChangeNotifier] / event delegate callbacks are notified about the
+  /// updated [SPConsent].
+  @override
+  Future<SPConsent> customConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) {
+    debugPrint('customConsentGdpr');
+    return _platform.customConsentGdpr(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories,
+    );
+  }
+
+  /// Programmatically delete custom GDPR consent for the supplied [vendors],
+  /// [categories] and [legIntCategories].
+  ///
+  /// The native SDK persists the consent locally and the registered
+  /// [ConsentChangeNotifier] / event delegate callbacks are notified about the
+  /// updated [SPConsent].
+  @override
+  Future<SPConsent> deleteCustomConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) {
+    debugPrint('deleteCustomConsentGdpr');
+    return _platform.deleteCustomConsentGdpr(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories,
+    );
+  }
 }

--- a/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
+++ b/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
@@ -30,6 +30,68 @@ void main() {
     expect(r, isNotNull);
   });
 
+  test('customConsentGdpr', () async {
+    final config = SPConfig(
+      accountId: 22,
+      propertyId: 7639,
+      propertyName: 'tcfv2.mobile.webview',
+      pmId: '122058',
+      campaigns: [CampaignType.gdpr],
+    );
+    when(
+      methodChannel.customConsentGdpr(
+        vendors: anyNamed('vendors'),
+        categories: anyNamed('categories'),
+        legIntCategories: anyNamed('legIntCategories'),
+      ),
+    ).thenAnswer((_) async => SPConsent());
+    final controller = SourcepointController(config: config);
+    final r = await controller.customConsentGdpr(
+      vendors: ['vendor1'],
+      categories: ['category1'],
+      legIntCategories: ['legIntCategory1'],
+    );
+    expect(r, isNotNull);
+    verify(
+      methodChannel.customConsentGdpr(
+        vendors: ['vendor1'],
+        categories: ['category1'],
+        legIntCategories: ['legIntCategory1'],
+      ),
+    ).called(1);
+  });
+
+  test('deleteCustomConsentGdpr', () async {
+    final config = SPConfig(
+      accountId: 22,
+      propertyId: 7639,
+      propertyName: 'tcfv2.mobile.webview',
+      pmId: '122058',
+      campaigns: [CampaignType.gdpr],
+    );
+    when(
+      methodChannel.deleteCustomConsentGdpr(
+        vendors: anyNamed('vendors'),
+        categories: anyNamed('categories'),
+        legIntCategories: anyNamed('legIntCategories'),
+      ),
+    ).thenAnswer((_) async => SPConsent());
+    final controller = SourcepointController(config: config);
+    final r = await controller.deleteCustomConsentGdpr(
+      vendors: ['vendor1'],
+      categories: ['category1'],
+      legIntCategories: ['legIntCategory1'],
+    );
+    expect(r, isNotNull);
+    verify(
+      methodChannel.deleteCustomConsentGdpr(
+        vendors: ['vendor1'],
+        categories: ['category1'],
+        legIntCategories: ['legIntCategory1'],
+      ),
+    ).called(1);
+  });
+
   group('WebView Utils', () {
     test(
       'generatePreloadJSString should return the correct JavaScript string',

--- a/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.mocks.dart
+++ b/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.mocks.dart
@@ -106,4 +106,74 @@ class MockMethodChannelSourcepointUnifiedCmp extends _i1.Mock
         Invocation.method(#registerEventDelegate, [delegate]),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i5.Future<_i3.SPConsent> customConsentGdpr({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#customConsentGdpr, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#customConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#customConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.SPConsent>);
+
+  @override
+  _i5.Future<_i3.SPConsent> deleteCustomConsentGdpr({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteCustomConsentGdpr, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#deleteCustomConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#deleteCustomConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.SPConsent>);
 }

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
@@ -888,6 +888,8 @@ private open class SourcepointUnifiedCmpPigeonCodec : StandardMessageCodec() {
 interface SourcepointUnifiedCmpHostApi {
   fun loadMessage(accountId: Long, propertyId: Long, propertyName: String, pmId: String, messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv, messageTimeout: Long, runGDPRCampaign: Boolean, runCCPACampaign: Boolean, runUSNATCampaign: Boolean, callback: (Result<HostAPISPConsent>) -> Unit)
   fun loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType, messageType: HostAPIMessageType, callback: (Result<Unit>) -> Unit)
+  fun customConsentGDPR(vendors: List<String>, categories: List<String>, legIntCategories: List<String>, callback: (Result<HostAPISPConsent>) -> Unit)
+  fun deleteCustomConsentGDPR(vendors: List<String>, categories: List<String>, legIntCategories: List<String>, callback: (Result<HostAPISPConsent>) -> Unit)
 
   companion object {
     /** The codec used by SourcepointUnifiedCmpHostApi. */
@@ -942,6 +944,50 @@ interface SourcepointUnifiedCmpHostApi {
                 reply.reply(SourcepointUnifiedCmpPigeonUtils.wrapError(error))
               } else {
                 reply.reply(SourcepointUnifiedCmpPigeonUtils.wrapResult(null))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.customConsentGDPR$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val vendorsArg = args[0] as List<String>
+            val categoriesArg = args[1] as List<String>
+            val legIntCategoriesArg = args[2] as List<String>
+            api.customConsentGDPR(vendorsArg, categoriesArg, legIntCategoriesArg) { result: Result<HostAPISPConsent> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(SourcepointUnifiedCmpPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(SourcepointUnifiedCmpPigeonUtils.wrapResult(data))
+              }
+            }
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { message, reply ->
+            val args = message as List<Any?>
+            val vendorsArg = args[0] as List<String>
+            val categoriesArg = args[1] as List<String>
+            val legIntCategoriesArg = args[2] as List<String>
+            api.deleteCustomConsentGDPR(vendorsArg, categoriesArg, legIntCategoriesArg) { result: Result<HostAPISPConsent> ->
+              val error = result.exceptionOrNull()
+              if (error != null) {
+                reply.reply(SourcepointUnifiedCmpPigeonUtils.wrapError(error))
+              } else {
+                val data = result.getOrNull()
+                reply.reply(SourcepointUnifiedCmpPigeonUtils.wrapResult(data))
               }
             }
           }

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmpPlugin.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmpPlugin.kt
@@ -41,10 +41,12 @@ private class SourcepointFlutterApi(
     }
 
     fun callOnConsentReady(consent: SPConsents, callback: (Result<Unit>) -> Unit) {
+        callOnConsentReady(consent.toHostAPISPConsent(), callback)
+    }
+
+    fun callOnConsentReady(hostConsent: HostAPISPConsent, callback: (Result<Unit>) -> Unit) {
         activity.runOnUiThread {
-            flutterApi!!.onConsentReady(
-                consent.toHostAPISPConsent()
-            ) { callback(Result.success(Unit)) }
+            flutterApi!!.onConsentReady(hostConsent) { callback(Result.success(Unit)) }
         }
     }
 
@@ -89,10 +91,12 @@ private class SourcepointFlutterApi(
     }
 
     fun callOnSpFinished(consent: SPConsents, callback: (Result<Unit>) -> Unit) {
+        callOnSpFinished(consent.toHostAPISPConsent(), callback)
+    }
+
+    fun callOnSpFinished(hostConsent: HostAPISPConsent, callback: (Result<Unit>) -> Unit) {
         activity.runOnUiThread {
-            flutterApi!!.onSpFinished(
-                consent.toHostAPISPConsent()
-            ) { callback(Result.success(Unit)) }
+            flutterApi!!.onSpFinished(hostConsent) { callback(Result.success(Unit)) }
         }
     }
 }
@@ -262,6 +266,68 @@ class SourcepointUnifiedCmpPlugin :
             pmTab.toPMTab(),
             campaignType.toCampaignType(),
             messageType.toMessageType()
+        )
+    }
+
+    override fun customConsentGDPR(
+        vendors: List<String>,
+        categories: List<String>,
+        legIntCategories: List<String>,
+        callback: (Result<HostAPISPConsent>) -> Unit
+    ) {
+        Log.d("SourcepointUnifiedCmp", "customConsentGDPR")
+        val lib = spConsentLib
+        if (lib == null) {
+            callback(
+                Result.failure(
+                    IllegalStateException(
+                        "SpConsentLib is not initialized. Call loadMessage first."
+                    )
+                )
+            )
+            return
+        }
+        lib.customConsentGDPR(
+            vendors = vendors,
+            categories = categories,
+            legIntCategories = legIntCategories,
+            success = { spConsents: SPConsents? ->
+                val hostConsent = spConsents?.toHostAPISPConsent() ?: HostAPISPConsent()
+                flutterApi.callOnConsentReady(hostConsent) {}
+                flutterApi.callOnSpFinished(hostConsent) {}
+                callback(Result.success(hostConsent))
+            }
+        )
+    }
+
+    override fun deleteCustomConsentGDPR(
+        vendors: List<String>,
+        categories: List<String>,
+        legIntCategories: List<String>,
+        callback: (Result<HostAPISPConsent>) -> Unit
+    ) {
+        Log.d("SourcepointUnifiedCmp", "deleteCustomConsentGDPR")
+        val lib = spConsentLib
+        if (lib == null) {
+            callback(
+                Result.failure(
+                    IllegalStateException(
+                        "SpConsentLib is not initialized. Call loadMessage first."
+                    )
+                )
+            )
+            return
+        }
+        lib.deleteCustomConsentTo(
+            vendors = vendors,
+            categories = categories,
+            legIntCategories = legIntCategories,
+            success = { spConsents: SPConsents? ->
+                val hostConsent = spConsents?.toHostAPISPConsent() ?: HostAPISPConsent()
+                flutterApi.callOnConsentReady(hostConsent) {}
+                flutterApi.callOnSpFinished(hostConsent) {}
+                callback(Result.success(hostConsent))
+            }
         )
     }
 }

--- a/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
@@ -287,6 +287,34 @@ class SourcepointUnifiedCmpAndroid extends SourcepointUnifiedCmpPlatform {
   }
 
   @override
+  Future<SPConsent> customConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final hostConsent = await _api.customConsentGDPR(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories,
+    );
+    return hostConsent.toSPConsent();
+  }
+
+  @override
+  Future<SPConsent> deleteCustomConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final hostConsent = await _api.deleteCustomConsentGDPR(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories,
+    );
+    return hostConsent.toSPConsent();
+  }
+
+  @override
   void registerConsentChangeNotifier(ConsentChangeNotifier notifier) {
     assert(_notifier == null, 'ConsentChangeNotifier already set');
     messages.SourcepointUnifiedCmpFlutterApi.setUp(

--- a/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
@@ -10,9 +10,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-  List<Object?>? replyList,
-  String channelName, {
-  required bool isNullValid,
+    List<Object?>? replyList,
+    String channelName, {
+    required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -34,11 +34,8 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-List<Object?> wrapResponse({
-  Object? result,
-  PlatformException? error,
-  bool empty = false,
-}) {
+
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -47,7 +44,6 @@ List<Object?> wrapResponse({
   }
   return <Object?>[error.code, error.message, error.details];
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (identical(a, b)) {
     return true;
@@ -60,9 +56,8 @@ bool _deepEquals(Object? a, Object? b) {
   }
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed.every(
-          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
-        );
+        a.indexed
+            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
     if (a.length != b.length) {
@@ -111,13 +106,32 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
-enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa, usnat }
+enum HostAPIPMTab {
+  defaults,
+  purposes,
+  vendors,
+  features,
+}
 
-enum HostAPIMessageType { mobile, ott, legacyOtt }
+enum HostAPICampaignType {
+  gdpr,
+  ccpa,
+  usnat,
+}
 
-enum HostAPIGranularState { all, some, none, emptyVl }
+enum HostAPIMessageType {
+  mobile,
+  ott,
+  legacyOtt,
+}
+
+enum HostAPIGranularState {
+  all,
+  some,
+  none,
+  emptyVl,
+}
 
 enum HostAPIActionType {
   showOptions,
@@ -132,9 +146,19 @@ enum HostAPIActionType {
   unknown,
 }
 
-enum HostAPIMessageLanguage { english, french, german, italian, spanish, dutch }
+enum HostAPIMessageLanguage {
+  english,
+  french,
+  german,
+  italian,
+  spanish,
+  dutch,
+}
 
-enum HostAPICampaignsEnv { stage, public }
+enum HostAPICampaignsEnv {
+  stage,
+  public,
+}
 
 class HostAPIConsentAction {
   HostAPIConsentAction({
@@ -153,12 +177,16 @@ class HostAPIConsentAction {
   String? customActionId;
 
   List<Object?> _toList() {
-    return <Object?>[actionType, pubData, campaignType, customActionId];
+    return <Object?>[
+      actionType,
+      pubData,
+      campaignType,
+      customActionId,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIConsentAction decode(Object result) {
     result as List<Object?>;
@@ -179,10 +207,7 @@ class HostAPIConsentAction {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(actionType, other.actionType) &&
-        _deepEquals(pubData, other.pubData) &&
-        _deepEquals(campaignType, other.campaignType) &&
-        _deepEquals(customActionId, other.customActionId);
+    return _deepEquals(actionType, other.actionType) && _deepEquals(pubData, other.pubData) && _deepEquals(campaignType, other.campaignType) && _deepEquals(customActionId, other.customActionId);
   }
 
   @override
@@ -191,41 +216,43 @@ class HostAPIConsentAction {
 }
 
 class HostAPIGDPRPurposeGrants {
-  HostAPIGDPRPurposeGrants({required this.granted, this.purposeGrants});
+  HostAPIGDPRPurposeGrants({
+    required this.granted,
+    this.purposeGrants,
+  });
 
   bool granted;
 
   Map<String?, bool?>? purposeGrants;
 
   List<Object?> _toList() {
-    return <Object?>[granted, purposeGrants];
+    return <Object?>[
+      granted,
+      purposeGrants,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIGDPRPurposeGrants decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRPurposeGrants(
       granted: result[0]! as bool,
-      purposeGrants: (result[1] as Map<Object?, Object?>?)
-          ?.cast<String?, bool?>(),
+      purposeGrants: (result[1] as Map<Object?, Object?>?)?.cast<String?, bool?>(),
     );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! HostAPIGDPRPurposeGrants ||
-        other.runtimeType != runtimeType) {
+    if (other is! HostAPIGDPRPurposeGrants || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(granted, other.granted) &&
-        _deepEquals(purposeGrants, other.purposeGrants);
+    return _deepEquals(granted, other.granted) && _deepEquals(purposeGrants, other.purposeGrants);
   }
 
   @override
@@ -234,19 +261,24 @@ class HostAPIGDPRPurposeGrants {
 }
 
 class HostAPISPError {
-  HostAPISPError({required this.cause, required this.message});
+  HostAPISPError({
+    required this.cause,
+    required this.message,
+  });
 
   String cause;
 
   String message;
 
   List<Object?> _toList() {
-    return <Object?>[cause, message];
+    return <Object?>[
+      cause,
+      message,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPISPError decode(Object result) {
     result as List<Object?>;
@@ -265,8 +297,7 @@ class HostAPISPError {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(cause, other.cause) &&
-        _deepEquals(message, other.message);
+    return _deepEquals(cause, other.cause) && _deepEquals(message, other.message);
   }
 
   @override
@@ -308,8 +339,7 @@ class HostAPIGranularStatus {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIGranularStatus decode(Object result) {
     result as List<Object?>;
@@ -332,12 +362,7 @@ class HostAPIGranularStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(defaultConsent, other.defaultConsent) &&
-        _deepEquals(previousOptInAll, other.previousOptInAll) &&
-        _deepEquals(purposeConsent, other.purposeConsent) &&
-        _deepEquals(purposeLegInt, other.purposeLegInt) &&
-        _deepEquals(vendorConsent, other.vendorConsent) &&
-        _deepEquals(vendorLegInt, other.vendorLegInt);
+    return _deepEquals(defaultConsent, other.defaultConsent) && _deepEquals(previousOptInAll, other.previousOptInAll) && _deepEquals(purposeConsent, other.purposeConsent) && _deepEquals(purposeLegInt, other.purposeLegInt) && _deepEquals(vendorConsent, other.vendorConsent) && _deepEquals(vendorLegInt, other.vendorLegInt);
   }
 
   @override
@@ -387,8 +412,7 @@ class HostAPIConsentStatus {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIConsentStatus decode(Object result) {
     result as List<Object?>;
@@ -413,14 +437,7 @@ class HostAPIConsentStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(consentedAll, other.consentedAll) &&
-        _deepEquals(consentedToAny, other.consentedToAny) &&
-        _deepEquals(granularStatus, other.granularStatus) &&
-        _deepEquals(hasConsentData, other.hasConsentData) &&
-        _deepEquals(rejectedAny, other.rejectedAny) &&
-        _deepEquals(rejectedLI, other.rejectedLI) &&
-        _deepEquals(legalBasisChanges, other.legalBasisChanges) &&
-        _deepEquals(vendorListAdditions, other.vendorListAdditions);
+    return _deepEquals(consentedAll, other.consentedAll) && _deepEquals(consentedToAny, other.consentedToAny) && _deepEquals(granularStatus, other.granularStatus) && _deepEquals(hasConsentData, other.hasConsentData) && _deepEquals(rejectedAny, other.rejectedAny) && _deepEquals(rejectedLI, other.rejectedLI) && _deepEquals(legalBasisChanges, other.legalBasisChanges) && _deepEquals(vendorListAdditions, other.vendorListAdditions);
   }
 
   @override
@@ -466,16 +483,14 @@ class HostAPIGDPRConsent {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIGDPRConsent decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRConsent(
       uuid: result[0] as String?,
       tcData: (result[1] as Map<Object?, Object?>?)?.cast<String?, String?>(),
-      grants: (result[2] as Map<Object?, Object?>?)
-          ?.cast<String?, HostAPIGDPRPurposeGrants?>(),
+      grants: (result[2] as Map<Object?, Object?>?)?.cast<String?, HostAPIGDPRPurposeGrants?>(),
       euconsent: result[3]! as String,
       acceptedCategories: (result[4] as List<Object?>?)?.cast<String?>(),
       apply: result[5]! as bool,
@@ -492,13 +507,7 @@ class HostAPIGDPRConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) &&
-        _deepEquals(tcData, other.tcData) &&
-        _deepEquals(grants, other.grants) &&
-        _deepEquals(euconsent, other.euconsent) &&
-        _deepEquals(acceptedCategories, other.acceptedCategories) &&
-        _deepEquals(apply, other.apply) &&
-        _deepEquals(consentStatus, other.consentStatus);
+    return _deepEquals(uuid, other.uuid) && _deepEquals(tcData, other.tcData) && _deepEquals(grants, other.grants) && _deepEquals(euconsent, other.euconsent) && _deepEquals(acceptedCategories, other.acceptedCategories) && _deepEquals(apply, other.apply) && _deepEquals(consentStatus, other.consentStatus);
   }
 
   @override
@@ -540,8 +549,7 @@ class HostAPICCPAConsent {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPICCPAConsent decode(Object result) {
     result as List<Object?>;
@@ -564,12 +572,7 @@ class HostAPICCPAConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) &&
-        _deepEquals(rejectedCategories, other.rejectedCategories) &&
-        _deepEquals(rejectedVendors, other.rejectedVendors) &&
-        _deepEquals(status, other.status) &&
-        _deepEquals(uspstring, other.uspstring) &&
-        _deepEquals(apply, other.apply);
+    return _deepEquals(uuid, other.uuid) && _deepEquals(rejectedCategories, other.rejectedCategories) && _deepEquals(rejectedVendors, other.rejectedVendors) && _deepEquals(status, other.status) && _deepEquals(uspstring, other.uspstring) && _deepEquals(apply, other.apply);
   }
 
   @override
@@ -578,7 +581,11 @@ class HostAPICCPAConsent {
 }
 
 class HostAPISPConsent {
-  HostAPISPConsent({this.gdpr, this.ccpa, this.webConsents});
+  HostAPISPConsent({
+    this.gdpr,
+    this.ccpa,
+    this.webConsents,
+  });
 
   HostAPIGDPRConsent? gdpr;
 
@@ -587,12 +594,15 @@ class HostAPISPConsent {
   String? webConsents;
 
   List<Object?> _toList() {
-    return <Object?>[gdpr, ccpa, webConsents];
+    return <Object?>[
+      gdpr,
+      ccpa,
+      webConsents,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPISPConsent decode(Object result) {
     result as List<Object?>;
@@ -612,9 +622,7 @@ class HostAPISPConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(gdpr, other.gdpr) &&
-        _deepEquals(ccpa, other.ccpa) &&
-        _deepEquals(webConsents, other.webConsents);
+    return _deepEquals(gdpr, other.gdpr) && _deepEquals(ccpa, other.ccpa) && _deepEquals(webConsents, other.webConsents);
   }
 
   @override
@@ -639,12 +647,16 @@ class SPConfig {
   String pmId;
 
   List<Object?> _toList() {
-    return <Object?>[accountId, propertyId, propertyName, pmId];
+    return <Object?>[
+      accountId,
+      propertyId,
+      propertyName,
+      pmId,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static SPConfig decode(Object result) {
     result as List<Object?>;
@@ -665,16 +677,14 @@ class SPConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(accountId, other.accountId) &&
-        _deepEquals(propertyId, other.propertyId) &&
-        _deepEquals(propertyName, other.propertyName) &&
-        _deepEquals(pmId, other.pmId);
+    return _deepEquals(accountId, other.accountId) && _deepEquals(propertyId, other.propertyId) && _deepEquals(propertyName, other.propertyName) && _deepEquals(pmId, other.pmId);
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -683,52 +693,52 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is HostAPIPMTab) {
+    }    else if (value is HostAPIPMTab) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is HostAPICampaignType) {
+    }    else if (value is HostAPICampaignType) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIMessageType) {
+    }    else if (value is HostAPIMessageType) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIGranularState) {
+    }    else if (value is HostAPIGranularState) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIActionType) {
+    }    else if (value is HostAPIActionType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIMessageLanguage) {
+    }    else if (value is HostAPIMessageLanguage) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is HostAPICampaignsEnv) {
+    }    else if (value is HostAPICampaignsEnv) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIConsentAction) {
+    }    else if (value is HostAPIConsentAction) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIGDPRPurposeGrants) {
+    }    else if (value is HostAPIGDPRPurposeGrants) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPISPError) {
+    }    else if (value is HostAPISPError) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIGranularStatus) {
+    }    else if (value is HostAPIGranularStatus) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIConsentStatus) {
+    }    else if (value is HostAPIConsentStatus) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIGDPRConsent) {
+    }    else if (value is HostAPIGDPRConsent) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPICCPAConsent) {
+    }    else if (value is HostAPICCPAConsent) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPISPConsent) {
+    }    else if (value is HostAPISPConsent) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is SPConfig) {
+    }    else if (value is SPConfig) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else {
@@ -788,84 +798,88 @@ class SourcepointUnifiedCmpHostApi {
   /// Constructor for [SourcepointUnifiedCmpHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  SourcepointUnifiedCmpHostApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  SourcepointUnifiedCmpHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<HostAPISPConsent> loadMessage({
-    required int accountId,
-    required int propertyId,
-    required String propertyName,
-    required String pmId,
-    required HostAPIMessageLanguage messageLanguage,
-    required HostAPICampaignsEnv campaignsEnv,
-    required int messageTimeout,
-    required bool runGDPRCampaign,
-    required bool runCCPACampaign,
-    required bool runUSNATCampaign,
-  }) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> loadMessage({required int accountId, required int propertyId, required String propertyName, required String pmId, required HostAPIMessageLanguage messageLanguage, required HostAPICampaignsEnv campaignsEnv, required int messageTimeout, required bool runGDPRCampaign, required bool runCCPACampaign, required bool runUSNATCampaign, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
-        .send(<Object?>[
-          accountId,
-          propertyId,
-          propertyName,
-          pmId,
-          messageLanguage,
-          campaignsEnv,
-          messageTimeout,
-          runGDPRCampaign,
-          runCCPACampaign,
-          runUSNATCampaign,
-        ]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[accountId, propertyId, propertyName, pmId, messageLanguage, campaignsEnv, messageTimeout, runGDPRCampaign, runCCPACampaign, runUSNATCampaign]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 
-  Future<void> loadPrivacyManager({
-    required String pmId,
-    required HostAPIPMTab pmTab,
-    required HostAPICampaignType campaignType,
-    required HostAPIMessageType messageType,
-  }) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
+  Future<void> loadPrivacyManager({required String pmId, required HostAPIPMTab pmTab, required HostAPICampaignType campaignType, required HostAPIMessageType messageType, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[pmId, pmTab, campaignType, messageType],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[pmId, pmTab, campaignType, messageType]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-      pigeonVar_replyList,
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  Future<HostAPISPConsent> customConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.customConsentGDPR$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
-      isNullValid: true,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
     );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as HostAPISPConsent;
+  }
+
+  Future<HostAPISPConsent> deleteCustomConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as HostAPISPConsent;
   }
 }
 
@@ -886,20 +900,12 @@ abstract class SourcepointUnifiedCmpFlutterApi {
 
   void onSpFinished(HostAPISPConsent consent);
 
-  static void setUp(
-    SourcepointUnifiedCmpFlutterApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+  static void setUp(SourcepointUnifiedCmpFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -909,20 +915,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -932,20 +934,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -957,20 +955,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -982,46 +976,37 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final HostAPIConsentAction arg_consentAction =
-              args[0]! as HostAPIConsentAction;
+          final HostAPIConsentAction arg_consentAction = args[0]! as HostAPIConsentAction;
           try {
             api.onAction(arg_consentAction);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1033,20 +1018,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1058,10 +1039,8 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
@@ -10,9 +10,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-    List<Object?>? replyList,
-    String channelName, {
-    required bool isNullValid,
+  List<Object?>? replyList,
+  String channelName, {
+  required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -34,8 +34,11 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-
-List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -44,6 +47,7 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   }
   return <Object?>[error.code, error.message, error.details];
 }
+
 bool _deepEquals(Object? a, Object? b) {
   if (identical(a, b)) {
     return true;
@@ -56,8 +60,9 @@ bool _deepEquals(Object? a, Object? b) {
   }
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed
-            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+        a.indexed.every(
+          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
+        );
   }
   if (a is Map && b is Map) {
     if (a.length != b.length) {
@@ -106,32 +111,13 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
+enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPIPMTab {
-  defaults,
-  purposes,
-  vendors,
-  features,
-}
+enum HostAPICampaignType { gdpr, ccpa, usnat }
 
-enum HostAPICampaignType {
-  gdpr,
-  ccpa,
-  usnat,
-}
+enum HostAPIMessageType { mobile, ott, legacyOtt }
 
-enum HostAPIMessageType {
-  mobile,
-  ott,
-  legacyOtt,
-}
-
-enum HostAPIGranularState {
-  all,
-  some,
-  none,
-  emptyVl,
-}
+enum HostAPIGranularState { all, some, none, emptyVl }
 
 enum HostAPIActionType {
   showOptions,
@@ -146,19 +132,9 @@ enum HostAPIActionType {
   unknown,
 }
 
-enum HostAPIMessageLanguage {
-  english,
-  french,
-  german,
-  italian,
-  spanish,
-  dutch,
-}
+enum HostAPIMessageLanguage { english, french, german, italian, spanish, dutch }
 
-enum HostAPICampaignsEnv {
-  stage,
-  public,
-}
+enum HostAPICampaignsEnv { stage, public }
 
 class HostAPIConsentAction {
   HostAPIConsentAction({
@@ -177,16 +153,12 @@ class HostAPIConsentAction {
   String? customActionId;
 
   List<Object?> _toList() {
-    return <Object?>[
-      actionType,
-      pubData,
-      campaignType,
-      customActionId,
-    ];
+    return <Object?>[actionType, pubData, campaignType, customActionId];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIConsentAction decode(Object result) {
     result as List<Object?>;
@@ -207,7 +179,10 @@ class HostAPIConsentAction {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(actionType, other.actionType) && _deepEquals(pubData, other.pubData) && _deepEquals(campaignType, other.campaignType) && _deepEquals(customActionId, other.customActionId);
+    return _deepEquals(actionType, other.actionType) &&
+        _deepEquals(pubData, other.pubData) &&
+        _deepEquals(campaignType, other.campaignType) &&
+        _deepEquals(customActionId, other.customActionId);
   }
 
   @override
@@ -216,43 +191,41 @@ class HostAPIConsentAction {
 }
 
 class HostAPIGDPRPurposeGrants {
-  HostAPIGDPRPurposeGrants({
-    required this.granted,
-    this.purposeGrants,
-  });
+  HostAPIGDPRPurposeGrants({required this.granted, this.purposeGrants});
 
   bool granted;
 
   Map<String?, bool?>? purposeGrants;
 
   List<Object?> _toList() {
-    return <Object?>[
-      granted,
-      purposeGrants,
-    ];
+    return <Object?>[granted, purposeGrants];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIGDPRPurposeGrants decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRPurposeGrants(
       granted: result[0]! as bool,
-      purposeGrants: (result[1] as Map<Object?, Object?>?)?.cast<String?, bool?>(),
+      purposeGrants: (result[1] as Map<Object?, Object?>?)
+          ?.cast<String?, bool?>(),
     );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! HostAPIGDPRPurposeGrants || other.runtimeType != runtimeType) {
+    if (other is! HostAPIGDPRPurposeGrants ||
+        other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(granted, other.granted) && _deepEquals(purposeGrants, other.purposeGrants);
+    return _deepEquals(granted, other.granted) &&
+        _deepEquals(purposeGrants, other.purposeGrants);
   }
 
   @override
@@ -261,24 +234,19 @@ class HostAPIGDPRPurposeGrants {
 }
 
 class HostAPISPError {
-  HostAPISPError({
-    required this.cause,
-    required this.message,
-  });
+  HostAPISPError({required this.cause, required this.message});
 
   String cause;
 
   String message;
 
   List<Object?> _toList() {
-    return <Object?>[
-      cause,
-      message,
-    ];
+    return <Object?>[cause, message];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPISPError decode(Object result) {
     result as List<Object?>;
@@ -297,7 +265,8 @@ class HostAPISPError {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(cause, other.cause) && _deepEquals(message, other.message);
+    return _deepEquals(cause, other.cause) &&
+        _deepEquals(message, other.message);
   }
 
   @override
@@ -339,7 +308,8 @@ class HostAPIGranularStatus {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIGranularStatus decode(Object result) {
     result as List<Object?>;
@@ -362,7 +332,12 @@ class HostAPIGranularStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(defaultConsent, other.defaultConsent) && _deepEquals(previousOptInAll, other.previousOptInAll) && _deepEquals(purposeConsent, other.purposeConsent) && _deepEquals(purposeLegInt, other.purposeLegInt) && _deepEquals(vendorConsent, other.vendorConsent) && _deepEquals(vendorLegInt, other.vendorLegInt);
+    return _deepEquals(defaultConsent, other.defaultConsent) &&
+        _deepEquals(previousOptInAll, other.previousOptInAll) &&
+        _deepEquals(purposeConsent, other.purposeConsent) &&
+        _deepEquals(purposeLegInt, other.purposeLegInt) &&
+        _deepEquals(vendorConsent, other.vendorConsent) &&
+        _deepEquals(vendorLegInt, other.vendorLegInt);
   }
 
   @override
@@ -412,7 +387,8 @@ class HostAPIConsentStatus {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIConsentStatus decode(Object result) {
     result as List<Object?>;
@@ -437,7 +413,14 @@ class HostAPIConsentStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(consentedAll, other.consentedAll) && _deepEquals(consentedToAny, other.consentedToAny) && _deepEquals(granularStatus, other.granularStatus) && _deepEquals(hasConsentData, other.hasConsentData) && _deepEquals(rejectedAny, other.rejectedAny) && _deepEquals(rejectedLI, other.rejectedLI) && _deepEquals(legalBasisChanges, other.legalBasisChanges) && _deepEquals(vendorListAdditions, other.vendorListAdditions);
+    return _deepEquals(consentedAll, other.consentedAll) &&
+        _deepEquals(consentedToAny, other.consentedToAny) &&
+        _deepEquals(granularStatus, other.granularStatus) &&
+        _deepEquals(hasConsentData, other.hasConsentData) &&
+        _deepEquals(rejectedAny, other.rejectedAny) &&
+        _deepEquals(rejectedLI, other.rejectedLI) &&
+        _deepEquals(legalBasisChanges, other.legalBasisChanges) &&
+        _deepEquals(vendorListAdditions, other.vendorListAdditions);
   }
 
   @override
@@ -483,14 +466,16 @@ class HostAPIGDPRConsent {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIGDPRConsent decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRConsent(
       uuid: result[0] as String?,
       tcData: (result[1] as Map<Object?, Object?>?)?.cast<String?, String?>(),
-      grants: (result[2] as Map<Object?, Object?>?)?.cast<String?, HostAPIGDPRPurposeGrants?>(),
+      grants: (result[2] as Map<Object?, Object?>?)
+          ?.cast<String?, HostAPIGDPRPurposeGrants?>(),
       euconsent: result[3]! as String,
       acceptedCategories: (result[4] as List<Object?>?)?.cast<String?>(),
       apply: result[5]! as bool,
@@ -507,7 +492,13 @@ class HostAPIGDPRConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) && _deepEquals(tcData, other.tcData) && _deepEquals(grants, other.grants) && _deepEquals(euconsent, other.euconsent) && _deepEquals(acceptedCategories, other.acceptedCategories) && _deepEquals(apply, other.apply) && _deepEquals(consentStatus, other.consentStatus);
+    return _deepEquals(uuid, other.uuid) &&
+        _deepEquals(tcData, other.tcData) &&
+        _deepEquals(grants, other.grants) &&
+        _deepEquals(euconsent, other.euconsent) &&
+        _deepEquals(acceptedCategories, other.acceptedCategories) &&
+        _deepEquals(apply, other.apply) &&
+        _deepEquals(consentStatus, other.consentStatus);
   }
 
   @override
@@ -549,7 +540,8 @@ class HostAPICCPAConsent {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPICCPAConsent decode(Object result) {
     result as List<Object?>;
@@ -572,7 +564,12 @@ class HostAPICCPAConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) && _deepEquals(rejectedCategories, other.rejectedCategories) && _deepEquals(rejectedVendors, other.rejectedVendors) && _deepEquals(status, other.status) && _deepEquals(uspstring, other.uspstring) && _deepEquals(apply, other.apply);
+    return _deepEquals(uuid, other.uuid) &&
+        _deepEquals(rejectedCategories, other.rejectedCategories) &&
+        _deepEquals(rejectedVendors, other.rejectedVendors) &&
+        _deepEquals(status, other.status) &&
+        _deepEquals(uspstring, other.uspstring) &&
+        _deepEquals(apply, other.apply);
   }
 
   @override
@@ -581,11 +578,7 @@ class HostAPICCPAConsent {
 }
 
 class HostAPISPConsent {
-  HostAPISPConsent({
-    this.gdpr,
-    this.ccpa,
-    this.webConsents,
-  });
+  HostAPISPConsent({this.gdpr, this.ccpa, this.webConsents});
 
   HostAPIGDPRConsent? gdpr;
 
@@ -594,15 +587,12 @@ class HostAPISPConsent {
   String? webConsents;
 
   List<Object?> _toList() {
-    return <Object?>[
-      gdpr,
-      ccpa,
-      webConsents,
-    ];
+    return <Object?>[gdpr, ccpa, webConsents];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPISPConsent decode(Object result) {
     result as List<Object?>;
@@ -622,7 +612,9 @@ class HostAPISPConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(gdpr, other.gdpr) && _deepEquals(ccpa, other.ccpa) && _deepEquals(webConsents, other.webConsents);
+    return _deepEquals(gdpr, other.gdpr) &&
+        _deepEquals(ccpa, other.ccpa) &&
+        _deepEquals(webConsents, other.webConsents);
   }
 
   @override
@@ -647,16 +639,12 @@ class SPConfig {
   String pmId;
 
   List<Object?> _toList() {
-    return <Object?>[
-      accountId,
-      propertyId,
-      propertyName,
-      pmId,
-    ];
+    return <Object?>[accountId, propertyId, propertyName, pmId];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static SPConfig decode(Object result) {
     result as List<Object?>;
@@ -677,14 +665,16 @@ class SPConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(accountId, other.accountId) && _deepEquals(propertyId, other.propertyId) && _deepEquals(propertyName, other.propertyName) && _deepEquals(pmId, other.pmId);
+    return _deepEquals(accountId, other.accountId) &&
+        _deepEquals(propertyId, other.propertyId) &&
+        _deepEquals(propertyName, other.propertyName) &&
+        _deepEquals(pmId, other.pmId);
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
-
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -693,52 +683,52 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is HostAPIPMTab) {
+    } else if (value is HostAPIPMTab) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPICampaignType) {
+    } else if (value is HostAPICampaignType) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIMessageType) {
+    } else if (value is HostAPIMessageType) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIGranularState) {
+    } else if (value is HostAPIGranularState) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIActionType) {
+    } else if (value is HostAPIActionType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIMessageLanguage) {
+    } else if (value is HostAPIMessageLanguage) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPICampaignsEnv) {
+    } else if (value is HostAPICampaignsEnv) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIConsentAction) {
+    } else if (value is HostAPIConsentAction) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIGDPRPurposeGrants) {
+    } else if (value is HostAPIGDPRPurposeGrants) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPISPError) {
+    } else if (value is HostAPISPError) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIGranularStatus) {
+    } else if (value is HostAPIGranularStatus) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIConsentStatus) {
+    } else if (value is HostAPIConsentStatus) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIGDPRConsent) {
+    } else if (value is HostAPIGDPRConsent) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPICCPAConsent) {
+    } else if (value is HostAPICCPAConsent) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPISPConsent) {
+    } else if (value is HostAPISPConsent) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    }    else if (value is SPConfig) {
+    } else if (value is SPConfig) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else {
@@ -798,87 +788,133 @@ class SourcepointUnifiedCmpHostApi {
   /// Constructor for [SourcepointUnifiedCmpHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  SourcepointUnifiedCmpHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  SourcepointUnifiedCmpHostApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
+           ? '.$messageChannelSuffix'
+           : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<HostAPISPConsent> loadMessage({required int accountId, required int propertyId, required String propertyName, required String pmId, required HostAPIMessageLanguage messageLanguage, required HostAPICampaignsEnv campaignsEnv, required int messageTimeout, required bool runGDPRCampaign, required bool runCCPACampaign, required bool runUSNATCampaign, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> loadMessage({
+    required int accountId,
+    required int propertyId,
+    required String propertyName,
+    required String pmId,
+    required HostAPIMessageLanguage messageLanguage,
+    required HostAPICampaignsEnv campaignsEnv,
+    required int messageTimeout,
+    required bool runGDPRCampaign,
+    required bool runCCPACampaign,
+    required bool runUSNATCampaign,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[accountId, propertyId, propertyName, pmId, messageLanguage, campaignsEnv, messageTimeout, runGDPRCampaign, runCCPACampaign, runUSNATCampaign]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[
+          accountId,
+          propertyId,
+          propertyName,
+          pmId,
+          messageLanguage,
+          campaignsEnv,
+          messageTimeout,
+          runGDPRCampaign,
+          runCCPACampaign,
+          runUSNATCampaign,
+        ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 
-  Future<void> loadPrivacyManager({required String pmId, required HostAPIPMTab pmTab, required HostAPICampaignType campaignType, required HostAPIMessageType messageType, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
+  Future<void> loadPrivacyManager({
+    required String pmId,
+    required HostAPIPMTab pmTab,
+    required HostAPICampaignType campaignType,
+    required HostAPIMessageType messageType,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[pmId, pmTab, campaignType, messageType]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[pmId, pmTab, campaignType, messageType],
+    );
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
-  Future<HostAPISPConsent> customConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.customConsentGDPR$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> customConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.customConsentGDPR$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[vendors, categories, legIntCategories],
+    );
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 
-  Future<HostAPISPConsent> deleteCustomConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> deleteCustomConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[vendors, categories, legIntCategories],
+    );
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 }
@@ -900,12 +936,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
 
   void onSpFinished(HostAPISPConsent consent);
 
-  static void setUp(SourcepointUnifiedCmpFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(
+    SourcepointUnifiedCmpFlutterApi? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty
+        ? '.$messageChannelSuffix'
+        : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -915,16 +959,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -934,16 +982,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -955,16 +1007,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -976,37 +1032,46 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final HostAPIConsentAction arg_consentAction = args[0]! as HostAPIConsentAction;
+          final HostAPIConsentAction arg_consentAction =
+              args[0]! as HostAPIConsentAction;
           try {
             api.onAction(arg_consentAction);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1018,16 +1083,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_android.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1039,8 +1108,10 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }

--- a/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
@@ -180,6 +180,20 @@ abstract class SourcepointUnifiedCmpHostApi {
     required HostAPICampaignType campaignType,
     required HostAPIMessageType messageType,
   });
+
+  @async
+  HostAPISPConsent customConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  });
+
+  @async
+  HostAPISPConsent deleteCustomConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  });
 }
 
 @FlutterApi()

--- a/packages/sourcepoint_unified_cmp_android/test/sourcepoint_unified_cmp_android_test.dart
+++ b/packages/sourcepoint_unified_cmp_android/test/sourcepoint_unified_cmp_android_test.dart
@@ -43,4 +43,36 @@ void main() {
     );
     expect(consent, isNotNull);
   });
+
+  test('customConsentGDPR', () async {
+    when(
+      api.customConsentGDPR(
+        vendors: ['vendor1'],
+        categories: ['category1'],
+        legIntCategories: ['legIntCategory1'],
+      ),
+    ).thenAnswer((_) async => HostAPISPConsent());
+    final consent = await api.customConsentGDPR(
+      vendors: ['vendor1'],
+      categories: ['category1'],
+      legIntCategories: ['legIntCategory1'],
+    );
+    expect(consent, isNotNull);
+  });
+
+  test('deleteCustomConsentGDPR', () async {
+    when(
+      api.deleteCustomConsentGDPR(
+        vendors: ['vendor1'],
+        categories: ['category1'],
+        legIntCategories: ['legIntCategory1'],
+      ),
+    ).thenAnswer((_) async => HostAPISPConsent());
+    final consent = await api.deleteCustomConsentGDPR(
+      vendors: ['vendor1'],
+      categories: ['category1'],
+      legIntCategories: ['legIntCategory1'],
+    );
+    expect(consent, isNotNull);
+  });
 }

--- a/packages/sourcepoint_unified_cmp_android/test/sourcepoint_unified_cmp_android_test.mocks.dart
+++ b/packages/sourcepoint_unified_cmp_android/test/sourcepoint_unified_cmp_android_test.mocks.dart
@@ -131,4 +131,74 @@ class MockSourcepointUnifiedCmpHostApi extends _i1.Mock
             returnValueForMissingStub: _i4.Future<void>.value(),
           )
           as _i4.Future<void>);
+
+  @override
+  _i4.Future<_i2.HostAPISPConsent> customConsentGDPR({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#customConsentGDPR, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#customConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#customConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.HostAPISPConsent>);
+
+  @override
+  _i4.Future<_i2.HostAPISPConsent> deleteCustomConsentGDPR({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteCustomConsentGDPR, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#deleteCustomConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#deleteCustomConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.HostAPISPConsent>);
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
@@ -70,6 +70,39 @@ extension SPUserData {
   }
 }
 
+extension SPGDPRConsent {
+  func toHostAPIGDPRConsent() -> HostAPIGDPRConsent {
+    let tcData: [String?: String?]? = tcfData?.dictionaryValue?
+      .reduce(into: [:]) { result, pair in
+        let value: String? = (pair.value as? String) ??
+          (pair.value as? CustomStringConvertible)?.description
+        result[pair.key] = value
+      }
+
+    let grants: [String?: HostAPIGDPRPurposeGrants?]? = vendorGrants
+      .reduce(into: [:]) { result, pair in
+        result[pair.key] = pair.value.toHostAPIPurposeGrants()
+      }
+
+    return HostAPIGDPRConsent(
+      uuid: uuid,
+      tcData: tcData,
+      grants: grants,
+      euconsent: euconsent,
+      acceptedCategories: acceptedCategories,
+      apply: applies,
+      consentStatus: consentStatus.toHostAPIConsentStatus()
+    )
+  }
+
+  func toHostAPISPConsent() -> HostAPISPConsent {
+    HostAPISPConsent(
+      gdpr: toHostAPIGDPRConsent(),
+      webConsents: nil
+    )
+  }
+}
+
 extension HostAPICampaignsEnv {
   func toSPCampaignEnv() -> SPCampaignEnv {
     switch self {

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
@@ -46,6 +46,50 @@ public class SourcepointUnifiedCmpPlugin: UIViewController, FlutterPlugin,
     }
   }
 
+  func customConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String],
+                         completion: @escaping (Result<HostAPISPConsent, Error>) -> Void) {
+    guard let consentManager else {
+      completion(.failure(FlutterError(
+        code: "not_initialized",
+        message: "SPConsentManager is not initialized. Call loadMessage first.",
+        details: nil
+      )))
+      return
+    }
+    consentManager.customConsentGDPR(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories
+    ) { [weak self] gdprConsent in
+      let hostConsent = gdprConsent.toHostAPISPConsent()
+      self?.flutterAPI?.callOnConsentReady(hostConsent: hostConsent)
+      self?.flutterAPI?.callOnSpFinished(hostConsent: hostConsent)
+      completion(.success(hostConsent))
+    }
+  }
+
+  func deleteCustomConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String],
+                               completion: @escaping (Result<HostAPISPConsent, Error>) -> Void) {
+    guard let consentManager else {
+      completion(.failure(FlutterError(
+        code: "not_initialized",
+        message: "SPConsentManager is not initialized. Call loadMessage first.",
+        details: nil
+      )))
+      return
+    }
+    consentManager.deleteCustomConsentGDPR(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories
+    ) { [weak self] gdprConsent in
+      let hostConsent = gdprConsent.toHostAPISPConsent()
+      self?.flutterAPI?.callOnConsentReady(hostConsent: hostConsent)
+      self?.flutterAPI?.callOnSpFinished(hostConsent: hostConsent)
+      completion(.success(hostConsent))
+    }
+  }
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     instance = SourcepointUnifiedCmpPlugin()
     instance?.onRegister(registrar)
@@ -69,6 +113,10 @@ private class SourcepointFlutterApi {
     flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
   }
 
+  func callOnConsentReady(hostConsent: HostAPISPConsent) {
+    flutterAPI.onConsentReady(consent: hostConsent) { _ in }
+  }
+
   func callOnUIReady(controller: UIViewController) {
     flutterAPI.onUIReady { _ in }
   }
@@ -85,6 +133,10 @@ private class SourcepointFlutterApi {
 
   func callOnSpFinished(userData: SPUserData) {
     flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
+  }
+
+  func callOnSpFinished(hostConsent: HostAPISPConsent) {
+    flutterAPI.onSpFinished(consent: hostConsent) { _ in }
   }
 
   func callOnError(error: SPError) {

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
@@ -24,13 +24,12 @@ final class HostApiFlutterError: Error {
   }
 
   var localizedDescription: String {
-    return
-      "HostApiFlutterError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
+    "HostApiFlutterError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
   }
 }
 
 private func wrapResult(_ result: Any?) -> [Any?] {
-  return [result]
+  [result]
 }
 
 private func wrapError(_ error: Any) -> [Any?] {
@@ -56,11 +55,15 @@ private func wrapError(_ error: Any) -> [Any?] {
 }
 
 private func createConnectionError(withChannelName channelName: String) -> HostApiFlutterError {
-  return HostApiFlutterError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
+  HostApiFlutterError(
+    code: "channel-error",
+    message: "Unable to establish connection on channel: '\(channelName)'.",
+    details: ""
+  )
 }
 
 private func isNullish(_ value: Any?) -> Bool {
-  return value is NSNull || value == nil
+  value is NSNull || value == nil
 }
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
@@ -69,12 +72,12 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
 }
 
 private func doubleEqualsSourcepointUnifiedCmp(_ lhs: Double, _ rhs: Double) -> Bool {
-  return (lhs.isNaN && rhs.isNaN) || lhs == rhs
+  (lhs.isNaN && rhs.isNaN) || lhs == rhs
 }
 
 private func doubleHashSourcepointUnifiedCmp(_ value: Double, _ hasher: inout Hasher) {
   if value.isNaN {
-    hasher.combine(0x7FF8000000000000)
+    hasher.combine(0x7FF8_0000_0000_0000)
   } else {
     // Normalize -0.0 to 0.0
     hasher.combine(value == 0 ? 0 : value)
@@ -91,13 +94,13 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
   case (nil, _), (_, nil):
     return false
 
-  case (let lhs as AnyObject, let rhs as AnyObject) where lhs === rhs:
+  case let (lhs as AnyObject, rhs as AnyObject) where lhs === rhs:
     return true
 
   case is (Void, Void):
     return true
 
-  case (let lhsArray, let rhsArray) as ([Any?], [Any?]):
+  case let (lhsArray, rhsArray) as ([Any?], [Any?]):
     guard lhsArray.count == rhsArray.count else { return false }
     for (index, element) in lhsArray.enumerated() {
       if !deepEqualsSourcepointUnifiedCmp(element, rhsArray[index]) {
@@ -106,7 +109,7 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
     }
     return true
 
-  case (let lhsArray, let rhsArray) as ([Double], [Double]):
+  case let (lhsArray, rhsArray) as ([Double], [Double]):
     guard lhsArray.count == rhsArray.count else { return false }
     for (index, element) in lhsArray.enumerated() {
       if !doubleEqualsSourcepointUnifiedCmp(element, rhsArray[index]) {
@@ -115,7 +118,7 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
     }
     return true
 
-  case (let lhsDictionary, let rhsDictionary) as ([AnyHashable: Any?], [AnyHashable: Any?]):
+  case let (lhsDictionary, rhsDictionary) as ([AnyHashable: Any?], [AnyHashable: Any?]):
     guard lhsDictionary.count == rhsDictionary.count else { return false }
     for (lhsKey, lhsValue) in lhsDictionary {
       var found = false
@@ -133,10 +136,10 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
     }
     return true
 
-  case (let lhs as Double, let rhs as Double):
+  case let (lhs as Double, rhs as Double):
     return doubleEqualsSourcepointUnifiedCmp(lhs, rhs)
 
-  case (let lhsHashable, let rhsHashable) as (AnyHashable, AnyHashable):
+  case let (lhsHashable, rhsHashable) as (AnyHashable, AnyHashable):
     return lhsHashable == rhsHashable
 
   default:
@@ -146,7 +149,7 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
 
 func deepHashSourcepointUnifiedCmp(value: Any?, hasher: inout Hasher) {
   let cleanValue = nilOrValue(value) as Any?
-  if let cleanValue = cleanValue {
+  if let cleanValue {
     if let doubleValue = cleanValue as? Double {
       doubleHashSourcepointUnifiedCmp(doubleValue, &hasher)
     } else if let valueList = cleanValue as? [Any?] {
@@ -176,7 +179,6 @@ func deepHashSourcepointUnifiedCmp(value: Any?, hasher: inout Hasher) {
     hasher.combine(0)
   }
 }
-
 
 enum HostAPIPMTab: Int {
   case defaults = 0
@@ -234,7 +236,6 @@ struct HostAPISPError: Hashable {
   var spCode: String
   var description: String
 
-
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPISPError? {
     let spCode = pigeonVar_list[0] as! String
@@ -245,17 +246,23 @@ struct HostAPISPError: Hashable {
       description: description
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       spCode,
       description,
     ]
   }
+
   static func == (lhs: HostAPISPError, rhs: HostAPISPError) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.spCode, rhs.spCode) && deepEqualsSourcepointUnifiedCmp(lhs.description, rhs.description)
+    return deepEqualsSourcepointUnifiedCmp(lhs.spCode, rhs.spCode) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.description,
+        rhs.description
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -270,8 +277,7 @@ struct HostAPIConsentAction: Hashable {
   var actionType: HostAPIActionType
   var pubData: String
   var campaignType: HostAPICampaignType
-  var customActionId: String? = nil
-
+  var customActionId: String?
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIConsentAction? {
@@ -287,19 +293,29 @@ struct HostAPIConsentAction: Hashable {
       customActionId: customActionId
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       actionType,
       pubData,
       campaignType,
       customActionId,
     ]
   }
+
   static func == (lhs: HostAPIConsentAction, rhs: HostAPIConsentAction) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.actionType, rhs.actionType) && deepEqualsSourcepointUnifiedCmp(lhs.pubData, rhs.pubData) && deepEqualsSourcepointUnifiedCmp(lhs.campaignType, rhs.campaignType) && deepEqualsSourcepointUnifiedCmp(lhs.customActionId, rhs.customActionId)
+    return deepEqualsSourcepointUnifiedCmp(lhs.actionType, rhs.actionType) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.pubData,
+        rhs.pubData
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.campaignType, rhs.campaignType) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.customActionId,
+        rhs.customActionId
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -314,8 +330,7 @@ struct HostAPIConsentAction: Hashable {
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIGDPRPurposeGrants: Hashable {
   var granted: Bool
-  var purposeGrants: [String?: Bool?]? = nil
-
+  var purposeGrants: [String?: Bool?]?
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIGDPRPurposeGrants? {
@@ -327,17 +342,23 @@ struct HostAPIGDPRPurposeGrants: Hashable {
       purposeGrants: purposeGrants
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       granted,
       purposeGrants,
     ]
   }
+
   static func == (lhs: HostAPIGDPRPurposeGrants, rhs: HostAPIGDPRPurposeGrants) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.granted, rhs.granted) && deepEqualsSourcepointUnifiedCmp(lhs.purposeGrants, rhs.purposeGrants)
+    return deepEqualsSourcepointUnifiedCmp(lhs.granted, rhs.granted) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.purposeGrants,
+        rhs.purposeGrants
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -349,13 +370,12 @@ struct HostAPIGDPRPurposeGrants: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIGranularStatus: Hashable {
-  var defaultConsent: Bool? = nil
-  var previousOptInAll: Bool? = nil
-  var purposeConsent: HostAPIGranularState? = nil
-  var purposeLegInt: HostAPIGranularState? = nil
-  var vendorConsent: HostAPIGranularState? = nil
-  var vendorLegInt: HostAPIGranularState? = nil
-
+  var defaultConsent: Bool?
+  var previousOptInAll: Bool?
+  var purposeConsent: HostAPIGranularState?
+  var purposeLegInt: HostAPIGranularState?
+  var vendorConsent: HostAPIGranularState?
+  var vendorLegInt: HostAPIGranularState?
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIGranularStatus? {
@@ -375,8 +395,9 @@ struct HostAPIGranularStatus: Hashable {
       vendorLegInt: vendorLegInt
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       defaultConsent,
       previousOptInAll,
       purposeConsent,
@@ -385,11 +406,24 @@ struct HostAPIGranularStatus: Hashable {
       vendorLegInt,
     ]
   }
+
   static func == (lhs: HostAPIGranularStatus, rhs: HostAPIGranularStatus) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.defaultConsent, rhs.defaultConsent) && deepEqualsSourcepointUnifiedCmp(lhs.previousOptInAll, rhs.previousOptInAll) && deepEqualsSourcepointUnifiedCmp(lhs.purposeConsent, rhs.purposeConsent) && deepEqualsSourcepointUnifiedCmp(lhs.purposeLegInt, rhs.purposeLegInt) && deepEqualsSourcepointUnifiedCmp(lhs.vendorConsent, rhs.vendorConsent) && deepEqualsSourcepointUnifiedCmp(lhs.vendorLegInt, rhs.vendorLegInt)
+    return deepEqualsSourcepointUnifiedCmp(lhs.defaultConsent, rhs.defaultConsent) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.previousOptInAll,
+        rhs.previousOptInAll
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.purposeConsent, rhs.purposeConsent) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.purposeLegInt,
+        rhs.purposeLegInt
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.vendorConsent, rhs.vendorConsent) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.vendorLegInt,
+        rhs.vendorLegInt
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -405,15 +439,14 @@ struct HostAPIGranularStatus: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIConsentStatus: Hashable {
-  var consentedAll: Bool? = nil
-  var consentedToAny: Bool? = nil
-  var granularStatus: HostAPIGranularStatus? = nil
-  var hasConsentData: Bool? = nil
-  var rejectedAny: Bool? = nil
-  var rejectedLI: Bool? = nil
-  var legalBasisChanges: Bool? = nil
-  var vendorListAdditions: Bool? = nil
-
+  var consentedAll: Bool?
+  var consentedToAny: Bool?
+  var granularStatus: HostAPIGranularStatus?
+  var hasConsentData: Bool?
+  var rejectedAny: Bool?
+  var rejectedLI: Bool?
+  var legalBasisChanges: Bool?
+  var vendorListAdditions: Bool?
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIConsentStatus? {
@@ -437,8 +470,9 @@ struct HostAPIConsentStatus: Hashable {
       vendorListAdditions: vendorListAdditions
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       consentedAll,
       consentedToAny,
       granularStatus,
@@ -449,11 +483,28 @@ struct HostAPIConsentStatus: Hashable {
       vendorListAdditions,
     ]
   }
+
   static func == (lhs: HostAPIConsentStatus, rhs: HostAPIConsentStatus) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.consentedAll, rhs.consentedAll) && deepEqualsSourcepointUnifiedCmp(lhs.consentedToAny, rhs.consentedToAny) && deepEqualsSourcepointUnifiedCmp(lhs.granularStatus, rhs.granularStatus) && deepEqualsSourcepointUnifiedCmp(lhs.hasConsentData, rhs.hasConsentData) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedAny, rhs.rejectedAny) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedLI, rhs.rejectedLI) && deepEqualsSourcepointUnifiedCmp(lhs.legalBasisChanges, rhs.legalBasisChanges) && deepEqualsSourcepointUnifiedCmp(lhs.vendorListAdditions, rhs.vendorListAdditions)
+    return deepEqualsSourcepointUnifiedCmp(lhs.consentedAll, rhs.consentedAll) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.consentedToAny,
+        rhs.consentedToAny
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.granularStatus, rhs.granularStatus) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.hasConsentData,
+        rhs.hasConsentData
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedAny, rhs.rejectedAny) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.rejectedLI,
+        rhs.rejectedLI
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.legalBasisChanges, rhs.legalBasisChanges) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.vendorListAdditions,
+        rhs.vendorListAdditions
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -471,14 +522,13 @@ struct HostAPIConsentStatus: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIGDPRConsent: Hashable {
-  var uuid: String? = nil
-  var tcData: [String?: String?]? = nil
-  var grants: [String?: HostAPIGDPRPurposeGrants?]? = nil
+  var uuid: String?
+  var tcData: [String?: String?]?
+  var grants: [String?: HostAPIGDPRPurposeGrants?]?
   var euconsent: String
-  var acceptedCategories: [String?]? = nil
+  var acceptedCategories: [String?]?
   var apply: Bool
-  var consentStatus: HostAPIConsentStatus? = nil
-
+  var consentStatus: HostAPIConsentStatus?
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIGDPRConsent? {
@@ -500,8 +550,9 @@ struct HostAPIGDPRConsent: Hashable {
       consentStatus: consentStatus
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       uuid,
       tcData,
       grants,
@@ -511,11 +562,22 @@ struct HostAPIGDPRConsent: Hashable {
       consentStatus,
     ]
   }
+
   static func == (lhs: HostAPIGDPRConsent, rhs: HostAPIGDPRConsent) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(lhs.tcData, rhs.tcData) && deepEqualsSourcepointUnifiedCmp(lhs.grants, rhs.grants) && deepEqualsSourcepointUnifiedCmp(lhs.euconsent, rhs.euconsent) && deepEqualsSourcepointUnifiedCmp(lhs.acceptedCategories, rhs.acceptedCategories) && deepEqualsSourcepointUnifiedCmp(lhs.apply, rhs.apply) && deepEqualsSourcepointUnifiedCmp(lhs.consentStatus, rhs.consentStatus)
+    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(
+      lhs.tcData,
+      rhs.tcData
+    ) && deepEqualsSourcepointUnifiedCmp(lhs.grants, rhs.grants) && deepEqualsSourcepointUnifiedCmp(
+      lhs.euconsent,
+      rhs.euconsent
+    ) && deepEqualsSourcepointUnifiedCmp(lhs.acceptedCategories, rhs.acceptedCategories) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.apply,
+        rhs.apply
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.consentStatus, rhs.consentStatus)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -532,13 +594,12 @@ struct HostAPIGDPRConsent: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPICCPAConsent: Hashable {
-  var uuid: String? = nil
-  var rejectedCategories: [String?]? = nil
-  var rejectedVendors: [String?]? = nil
-  var status: String? = nil
+  var uuid: String?
+  var rejectedCategories: [String?]?
+  var rejectedVendors: [String?]?
+  var status: String?
   var uspstring: String
   var apply: Bool
-
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPICCPAConsent? {
@@ -558,8 +619,9 @@ struct HostAPICCPAConsent: Hashable {
       apply: apply
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       uuid,
       rejectedCategories,
       rejectedVendors,
@@ -568,11 +630,23 @@ struct HostAPICCPAConsent: Hashable {
       apply,
     ]
   }
+
   static func == (lhs: HostAPICCPAConsent, rhs: HostAPICCPAConsent) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedCategories, rhs.rejectedCategories) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedVendors, rhs.rejectedVendors) && deepEqualsSourcepointUnifiedCmp(lhs.status, rhs.status) && deepEqualsSourcepointUnifiedCmp(lhs.uspstring, rhs.uspstring) && deepEqualsSourcepointUnifiedCmp(lhs.apply, rhs.apply)
+    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(
+      lhs.rejectedCategories,
+      rhs.rejectedCategories
+    ) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedVendors, rhs.rejectedVendors) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.status,
+        rhs.status
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.uspstring, rhs.uspstring) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.apply,
+        rhs.apply
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -588,10 +662,9 @@ struct HostAPICCPAConsent: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPISPConsent: Hashable {
-  var gdpr: HostAPIGDPRConsent? = nil
-  var ccpa: HostAPICCPAConsent? = nil
-  var webConsents: String? = nil
-
+  var gdpr: HostAPIGDPRConsent?
+  var ccpa: HostAPICCPAConsent?
+  var webConsents: String?
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPISPConsent? {
@@ -605,18 +678,23 @@ struct HostAPISPConsent: Hashable {
       webConsents: webConsents
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       gdpr,
       ccpa,
       webConsents,
     ]
   }
+
   static func == (lhs: HostAPISPConsent, rhs: HostAPISPConsent) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.gdpr, rhs.gdpr) && deepEqualsSourcepointUnifiedCmp(lhs.ccpa, rhs.ccpa) && deepEqualsSourcepointUnifiedCmp(lhs.webConsents, rhs.webConsents)
+    return deepEqualsSourcepointUnifiedCmp(lhs.gdpr, rhs.gdpr) && deepEqualsSourcepointUnifiedCmp(
+      lhs.ccpa,
+      rhs.ccpa
+    ) && deepEqualsSourcepointUnifiedCmp(lhs.webConsents, rhs.webConsents)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -634,7 +712,6 @@ struct SPConfig: Hashable {
   var propertyName: String
   var pmId: String
 
-
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> SPConfig? {
     let accountId = pigeonVar_list[0] as! Int64
@@ -649,19 +726,29 @@ struct SPConfig: Hashable {
       pmId: pmId
     )
   }
+
   func toList() -> [Any?] {
-    return [
+    [
       accountId,
       propertyId,
       propertyName,
       pmId,
     ]
   }
+
   static func == (lhs: SPConfig, rhs: SPConfig) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.accountId, rhs.accountId) && deepEqualsSourcepointUnifiedCmp(lhs.propertyId, rhs.propertyId) && deepEqualsSourcepointUnifiedCmp(lhs.propertyName, rhs.propertyName) && deepEqualsSourcepointUnifiedCmp(lhs.pmId, rhs.pmId)
+    return deepEqualsSourcepointUnifiedCmp(lhs.accountId, rhs.accountId) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.propertyId,
+        rhs.propertyId
+      ) && deepEqualsSourcepointUnifiedCmp(lhs.propertyName, rhs.propertyName) &&
+      deepEqualsSourcepointUnifiedCmp(
+        lhs.pmId,
+        rhs.pmId
+      )
   }
 
   func hash(into hasher: inout Hasher) {
@@ -677,65 +764,65 @@ private class SourcepointUnifiedCmpPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPIPMTab(rawValue: enumResultAsInt)
       }
       return nil
     case 130:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPICampaignType(rawValue: enumResultAsInt)
       }
       return nil
     case 131:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPIMessageType(rawValue: enumResultAsInt)
       }
       return nil
     case 132:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPIGranularState(rawValue: enumResultAsInt)
       }
       return nil
     case 133:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPIActionType(rawValue: enumResultAsInt)
       }
       return nil
     case 134:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPIMessageLanguage(rawValue: enumResultAsInt)
       }
       return nil
     case 135:
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
-      if let enumResultAsInt = enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
+      if let enumResultAsInt {
         return HostAPICampaignsEnv(rawValue: enumResultAsInt)
       }
       return nil
     case 136:
-      return HostAPISPError.fromList(self.readValue() as! [Any?])
+      return HostAPISPError.fromList(readValue() as! [Any?])
     case 137:
-      return HostAPIConsentAction.fromList(self.readValue() as! [Any?])
+      return HostAPIConsentAction.fromList(readValue() as! [Any?])
     case 138:
-      return HostAPIGDPRPurposeGrants.fromList(self.readValue() as! [Any?])
+      return HostAPIGDPRPurposeGrants.fromList(readValue() as! [Any?])
     case 139:
-      return HostAPIGranularStatus.fromList(self.readValue() as! [Any?])
+      return HostAPIGranularStatus.fromList(readValue() as! [Any?])
     case 140:
-      return HostAPIConsentStatus.fromList(self.readValue() as! [Any?])
+      return HostAPIConsentStatus.fromList(readValue() as! [Any?])
     case 141:
-      return HostAPIGDPRConsent.fromList(self.readValue() as! [Any?])
+      return HostAPIGDPRConsent.fromList(readValue() as! [Any?])
     case 142:
-      return HostAPICCPAConsent.fromList(self.readValue() as! [Any?])
+      return HostAPICCPAConsent.fromList(readValue() as! [Any?])
     case 143:
-      return HostAPISPConsent.fromList(self.readValue() as! [Any?])
+      return HostAPISPConsent.fromList(readValue() as! [Any?])
     case 144:
-      return SPConfig.fromList(self.readValue() as! [Any?])
+      return SPConfig.fromList(readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -800,35 +887,51 @@ private class SourcepointUnifiedCmpPigeonCodecWriter: FlutterStandardWriter {
 
 private class SourcepointUnifiedCmpPigeonCodecReaderWriter: FlutterStandardReaderWriter {
   override func reader(with data: Data) -> FlutterStandardReader {
-    return SourcepointUnifiedCmpPigeonCodecReader(data: data)
+    SourcepointUnifiedCmpPigeonCodecReader(data: data)
   }
 
   override func writer(with data: NSMutableData) -> FlutterStandardWriter {
-    return SourcepointUnifiedCmpPigeonCodecWriter(data: data)
+    SourcepointUnifiedCmpPigeonCodecWriter(data: data)
   }
 }
 
 class SourcepointUnifiedCmpPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
-  static let shared = SourcepointUnifiedCmpPigeonCodec(readerWriter: SourcepointUnifiedCmpPigeonCodecReaderWriter())
+  static let shared =
+    SourcepointUnifiedCmpPigeonCodec(readerWriter: SourcepointUnifiedCmpPigeonCodecReaderWriter())
 }
-
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol SourcepointUnifiedCmpHostApi {
-  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId: String, messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv, messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool, completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
-  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType, messageType: HostAPIMessageType, completion: @escaping (Result<Void, Error>) -> Void)
-  func customConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String], completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
-  func deleteCustomConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String], completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
+  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId: String,
+                   messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
+                   messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
+                   completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
+  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
+                          messageType: HostAPIMessageType,
+                          completion: @escaping (Result<Void, Error>) -> Void)
+  func customConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String],
+                         completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
+  func deleteCustomConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String],
+                               completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class SourcepointUnifiedCmpHostApiSetup {
-  static var codec: FlutterStandardMessageCodec { SourcepointUnifiedCmpPigeonCodec.shared }
-  /// Sets up an instance of `SourcepointUnifiedCmpHostApi` to handle messages through the `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: SourcepointUnifiedCmpHostApi?, messageChannelSuffix: String = "") {
+  static var codec: FlutterStandardMessageCodec {
+    SourcepointUnifiedCmpPigeonCodec.shared
+  }
+
+  /// Sets up an instance of `SourcepointUnifiedCmpHostApi` to handle messages through the
+  /// `binaryMessenger`.
+  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: SourcepointUnifiedCmpHostApi?,
+                    messageChannelSuffix: String = "") {
     let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    let loadMessageChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
+    let loadMessageChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage\(channelSuffix)",
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
+    if let api {
       loadMessageChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let accountIdArg = args[0] as! Int64
@@ -840,11 +943,21 @@ class SourcepointUnifiedCmpHostApiSetup {
         let messageTimeoutArg = args[6] as! Int64
         let runGDPRCampaignArg = args[7] as! Bool
         let runCCPACampaignArg = args[8] as! Bool
-        api.loadMessage(accountId: accountIdArg, propertyId: propertyIdArg, propertyName: propertyNameArg, pmId: pmIdArg, messageLanguage: messageLanguageArg, campaignsEnv: campaignsEnvArg, messageTimeout: messageTimeoutArg, runGDPRCampaign: runGDPRCampaignArg, runCCPACampaign: runCCPACampaignArg) { result in
+        api.loadMessage(
+          accountId: accountIdArg,
+          propertyId: propertyIdArg,
+          propertyName: propertyNameArg,
+          pmId: pmIdArg,
+          messageLanguage: messageLanguageArg,
+          campaignsEnv: campaignsEnvArg,
+          messageTimeout: messageTimeoutArg,
+          runGDPRCampaign: runGDPRCampaignArg,
+          runCCPACampaign: runCCPACampaignArg
+        ) { result in
           switch result {
-          case .success(let res):
+          case let .success(res):
             reply(wrapResult(res))
-          case .failure(let error):
+          case let .failure(error):
             reply(wrapError(error))
           }
         }
@@ -852,19 +965,28 @@ class SourcepointUnifiedCmpHostApiSetup {
     } else {
       loadMessageChannel.setMessageHandler(nil)
     }
-    let loadPrivacyManagerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
+    let loadPrivacyManagerChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager\(channelSuffix)",
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
+    if let api {
       loadPrivacyManagerChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let pmIdArg = args[0] as! String
         let pmTabArg = args[1] as! HostAPIPMTab
         let campaignTypeArg = args[2] as! HostAPICampaignType
         let messageTypeArg = args[3] as! HostAPIMessageType
-        api.loadPrivacyManager(pmId: pmIdArg, pmTab: pmTabArg, campaignType: campaignTypeArg, messageType: messageTypeArg) { result in
+        api.loadPrivacyManager(
+          pmId: pmIdArg,
+          pmTab: pmTabArg,
+          campaignType: campaignTypeArg,
+          messageType: messageTypeArg
+        ) { result in
           switch result {
           case .success:
             reply(wrapResult(nil))
-          case .failure(let error):
+          case let .failure(error):
             reply(wrapError(error))
           }
         }
@@ -872,18 +994,26 @@ class SourcepointUnifiedCmpHostApiSetup {
     } else {
       loadPrivacyManagerChannel.setMessageHandler(nil)
     }
-    let customConsentGDPRChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.customConsentGDPR\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
+    let customConsentGDPRChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.customConsentGDPR\(channelSuffix)",
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
+    if let api {
       customConsentGDPRChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let vendorsArg = args[0] as! [String]
         let categoriesArg = args[1] as! [String]
         let legIntCategoriesArg = args[2] as! [String]
-        api.customConsentGDPR(vendors: vendorsArg, categories: categoriesArg, legIntCategories: legIntCategoriesArg) { result in
+        api.customConsentGDPR(
+          vendors: vendorsArg,
+          categories: categoriesArg,
+          legIntCategories: legIntCategoriesArg
+        ) { result in
           switch result {
-          case .success(let res):
+          case let .success(res):
             reply(wrapResult(res))
-          case .failure(let error):
+          case let .failure(error):
             reply(wrapError(error))
           }
         }
@@ -891,18 +1021,26 @@ class SourcepointUnifiedCmpHostApiSetup {
     } else {
       customConsentGDPRChannel.setMessageHandler(nil)
     }
-    let deleteCustomConsentGDPRChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
+    let deleteCustomConsentGDPRChannel = FlutterBasicMessageChannel(
+      name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR\(channelSuffix)",
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
+    if let api {
       deleteCustomConsentGDPRChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let vendorsArg = args[0] as! [String]
         let categoriesArg = args[1] as! [String]
         let legIntCategoriesArg = args[2] as! [String]
-        api.deleteCustomConsentGDPR(vendors: vendorsArg, categories: categoriesArg, legIntCategories: legIntCategoriesArg) { result in
+        api.deleteCustomConsentGDPR(
+          vendors: vendorsArg,
+          categories: categoriesArg,
+          legIntCategories: legIntCategoriesArg
+        ) { result in
           switch result {
-          case .success(let res):
+          case let .success(res):
             reply(wrapResult(res))
-          case .failure(let error):
+          case let .failure(error):
             reply(wrapError(error))
           }
         }
@@ -912,16 +1050,23 @@ class SourcepointUnifiedCmpHostApiSetup {
     }
   }
 }
+
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol SourcepointUnifiedCmpFlutterApiProtocol {
   func onUIFinished(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
   func onUIReady(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onError(error errorArg: HostAPISPError, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onConsentReady(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onAction(consentAction consentActionArg: HostAPIConsentAction, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onNoIntentActivitiesFound(url urlArg: String, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onSpFinished(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onError(error errorArg: HostAPISPError,
+               completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onConsentReady(consent consentArg: HostAPISPConsent,
+                      completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onAction(consentAction consentActionArg: HostAPIConsentAction,
+                completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onNoIntentActivitiesFound(url urlArg: String,
+                                 completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onSpFinished(consent consentArg: HostAPISPConsent,
+                    completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
 }
+
 class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
   private let messageChannelSuffix: String
@@ -929,12 +1074,18 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
     self.binaryMessenger = binaryMessenger
     self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
   }
+
   var codec: SourcepointUnifiedCmpPigeonCodec {
-    return SourcepointUnifiedCmpPigeonCodec.shared
+    SourcepointUnifiedCmpPigeonCodec.shared
   }
+
   func onUIFinished(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage(nil) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -950,9 +1101,14 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
+
   func onUIReady(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage(nil) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -968,9 +1124,15 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-  func onError(error errorArg: HostAPISPError, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+
+  func onError(error errorArg: HostAPISPError,
+               completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage([errorArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -986,9 +1148,15 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-  func onConsentReady(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+
+  func onConsentReady(consent consentArg: HostAPISPConsent,
+                      completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage([consentArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1004,9 +1172,15 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-  func onAction(consentAction consentActionArg: HostAPIConsentAction, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+
+  func onAction(consentAction consentActionArg: HostAPIConsentAction,
+                completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage([consentActionArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1022,9 +1196,16 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-  func onNoIntentActivitiesFound(url urlArg: String, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+
+  func onNoIntentActivitiesFound(url urlArg: String,
+                                 completion: @escaping (Result<Void, HostApiFlutterError>)
+                                   -> Void) {
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage([urlArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1040,9 +1221,15 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-  func onSpFinished(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+
+  func onSpFinished(consent consentArg: HostAPISPConsent,
+                    completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(
+      name: channelName,
+      binaryMessenger: binaryMessenger,
+      codec: codec
+    )
     channel.sendMessage([consentArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
@@ -24,12 +24,13 @@ final class HostApiFlutterError: Error {
   }
 
   var localizedDescription: String {
-    "HostApiFlutterError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
+    return
+      "HostApiFlutterError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
   }
 }
 
 private func wrapResult(_ result: Any?) -> [Any?] {
-  [result]
+  return [result]
 }
 
 private func wrapError(_ error: Any) -> [Any?] {
@@ -55,15 +56,11 @@ private func wrapError(_ error: Any) -> [Any?] {
 }
 
 private func createConnectionError(withChannelName channelName: String) -> HostApiFlutterError {
-  HostApiFlutterError(
-    code: "channel-error",
-    message: "Unable to establish connection on channel: '\(channelName)'.",
-    details: ""
-  )
+  return HostApiFlutterError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
 }
 
 private func isNullish(_ value: Any?) -> Bool {
-  value is NSNull || value == nil
+  return value is NSNull || value == nil
 }
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
@@ -72,12 +69,12 @@ private func nilOrValue<T>(_ value: Any?) -> T? {
 }
 
 private func doubleEqualsSourcepointUnifiedCmp(_ lhs: Double, _ rhs: Double) -> Bool {
-  (lhs.isNaN && rhs.isNaN) || lhs == rhs
+  return (lhs.isNaN && rhs.isNaN) || lhs == rhs
 }
 
 private func doubleHashSourcepointUnifiedCmp(_ value: Double, _ hasher: inout Hasher) {
   if value.isNaN {
-    hasher.combine(0x7FF8_0000_0000_0000)
+    hasher.combine(0x7FF8000000000000)
   } else {
     // Normalize -0.0 to 0.0
     hasher.combine(value == 0 ? 0 : value)
@@ -94,13 +91,13 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
   case (nil, _), (_, nil):
     return false
 
-  case let (lhs as AnyObject, rhs as AnyObject) where lhs === rhs:
+  case (let lhs as AnyObject, let rhs as AnyObject) where lhs === rhs:
     return true
 
   case is (Void, Void):
     return true
 
-  case let (lhsArray, rhsArray) as ([Any?], [Any?]):
+  case (let lhsArray, let rhsArray) as ([Any?], [Any?]):
     guard lhsArray.count == rhsArray.count else { return false }
     for (index, element) in lhsArray.enumerated() {
       if !deepEqualsSourcepointUnifiedCmp(element, rhsArray[index]) {
@@ -109,7 +106,7 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
     }
     return true
 
-  case let (lhsArray, rhsArray) as ([Double], [Double]):
+  case (let lhsArray, let rhsArray) as ([Double], [Double]):
     guard lhsArray.count == rhsArray.count else { return false }
     for (index, element) in lhsArray.enumerated() {
       if !doubleEqualsSourcepointUnifiedCmp(element, rhsArray[index]) {
@@ -118,7 +115,7 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
     }
     return true
 
-  case let (lhsDictionary, rhsDictionary) as ([AnyHashable: Any?], [AnyHashable: Any?]):
+  case (let lhsDictionary, let rhsDictionary) as ([AnyHashable: Any?], [AnyHashable: Any?]):
     guard lhsDictionary.count == rhsDictionary.count else { return false }
     for (lhsKey, lhsValue) in lhsDictionary {
       var found = false
@@ -136,10 +133,10 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
     }
     return true
 
-  case let (lhs as Double, rhs as Double):
+  case (let lhs as Double, let rhs as Double):
     return doubleEqualsSourcepointUnifiedCmp(lhs, rhs)
 
-  case let (lhsHashable, rhsHashable) as (AnyHashable, AnyHashable):
+  case (let lhsHashable, let rhsHashable) as (AnyHashable, AnyHashable):
     return lhsHashable == rhsHashable
 
   default:
@@ -149,7 +146,7 @@ func deepEqualsSourcepointUnifiedCmp(_ lhs: Any?, _ rhs: Any?) -> Bool {
 
 func deepHashSourcepointUnifiedCmp(value: Any?, hasher: inout Hasher) {
   let cleanValue = nilOrValue(value) as Any?
-  if let cleanValue {
+  if let cleanValue = cleanValue {
     if let doubleValue = cleanValue as? Double {
       doubleHashSourcepointUnifiedCmp(doubleValue, &hasher)
     } else if let valueList = cleanValue as? [Any?] {
@@ -179,6 +176,7 @@ func deepHashSourcepointUnifiedCmp(value: Any?, hasher: inout Hasher) {
     hasher.combine(0)
   }
 }
+
 
 enum HostAPIPMTab: Int {
   case defaults = 0
@@ -236,6 +234,7 @@ struct HostAPISPError: Hashable {
   var spCode: String
   var description: String
 
+
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPISPError? {
     let spCode = pigeonVar_list[0] as! String
@@ -246,23 +245,17 @@ struct HostAPISPError: Hashable {
       description: description
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       spCode,
       description,
     ]
   }
-
   static func == (lhs: HostAPISPError, rhs: HostAPISPError) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.spCode, rhs.spCode) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.description,
-        rhs.description
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.spCode, rhs.spCode) && deepEqualsSourcepointUnifiedCmp(lhs.description, rhs.description)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -277,7 +270,8 @@ struct HostAPIConsentAction: Hashable {
   var actionType: HostAPIActionType
   var pubData: String
   var campaignType: HostAPICampaignType
-  var customActionId: String?
+  var customActionId: String? = nil
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIConsentAction? {
@@ -293,29 +287,19 @@ struct HostAPIConsentAction: Hashable {
       customActionId: customActionId
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       actionType,
       pubData,
       campaignType,
       customActionId,
     ]
   }
-
   static func == (lhs: HostAPIConsentAction, rhs: HostAPIConsentAction) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.actionType, rhs.actionType) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.pubData,
-        rhs.pubData
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.campaignType, rhs.campaignType) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.customActionId,
-        rhs.customActionId
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.actionType, rhs.actionType) && deepEqualsSourcepointUnifiedCmp(lhs.pubData, rhs.pubData) && deepEqualsSourcepointUnifiedCmp(lhs.campaignType, rhs.campaignType) && deepEqualsSourcepointUnifiedCmp(lhs.customActionId, rhs.customActionId)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -330,7 +314,8 @@ struct HostAPIConsentAction: Hashable {
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIGDPRPurposeGrants: Hashable {
   var granted: Bool
-  var purposeGrants: [String?: Bool?]?
+  var purposeGrants: [String?: Bool?]? = nil
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIGDPRPurposeGrants? {
@@ -342,23 +327,17 @@ struct HostAPIGDPRPurposeGrants: Hashable {
       purposeGrants: purposeGrants
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       granted,
       purposeGrants,
     ]
   }
-
   static func == (lhs: HostAPIGDPRPurposeGrants, rhs: HostAPIGDPRPurposeGrants) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.granted, rhs.granted) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.purposeGrants,
-        rhs.purposeGrants
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.granted, rhs.granted) && deepEqualsSourcepointUnifiedCmp(lhs.purposeGrants, rhs.purposeGrants)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -370,12 +349,13 @@ struct HostAPIGDPRPurposeGrants: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIGranularStatus: Hashable {
-  var defaultConsent: Bool?
-  var previousOptInAll: Bool?
-  var purposeConsent: HostAPIGranularState?
-  var purposeLegInt: HostAPIGranularState?
-  var vendorConsent: HostAPIGranularState?
-  var vendorLegInt: HostAPIGranularState?
+  var defaultConsent: Bool? = nil
+  var previousOptInAll: Bool? = nil
+  var purposeConsent: HostAPIGranularState? = nil
+  var purposeLegInt: HostAPIGranularState? = nil
+  var vendorConsent: HostAPIGranularState? = nil
+  var vendorLegInt: HostAPIGranularState? = nil
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIGranularStatus? {
@@ -395,9 +375,8 @@ struct HostAPIGranularStatus: Hashable {
       vendorLegInt: vendorLegInt
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       defaultConsent,
       previousOptInAll,
       purposeConsent,
@@ -406,24 +385,11 @@ struct HostAPIGranularStatus: Hashable {
       vendorLegInt,
     ]
   }
-
   static func == (lhs: HostAPIGranularStatus, rhs: HostAPIGranularStatus) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.defaultConsent, rhs.defaultConsent) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.previousOptInAll,
-        rhs.previousOptInAll
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.purposeConsent, rhs.purposeConsent) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.purposeLegInt,
-        rhs.purposeLegInt
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.vendorConsent, rhs.vendorConsent) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.vendorLegInt,
-        rhs.vendorLegInt
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.defaultConsent, rhs.defaultConsent) && deepEqualsSourcepointUnifiedCmp(lhs.previousOptInAll, rhs.previousOptInAll) && deepEqualsSourcepointUnifiedCmp(lhs.purposeConsent, rhs.purposeConsent) && deepEqualsSourcepointUnifiedCmp(lhs.purposeLegInt, rhs.purposeLegInt) && deepEqualsSourcepointUnifiedCmp(lhs.vendorConsent, rhs.vendorConsent) && deepEqualsSourcepointUnifiedCmp(lhs.vendorLegInt, rhs.vendorLegInt)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -439,14 +405,15 @@ struct HostAPIGranularStatus: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIConsentStatus: Hashable {
-  var consentedAll: Bool?
-  var consentedToAny: Bool?
-  var granularStatus: HostAPIGranularStatus?
-  var hasConsentData: Bool?
-  var rejectedAny: Bool?
-  var rejectedLI: Bool?
-  var legalBasisChanges: Bool?
-  var vendorListAdditions: Bool?
+  var consentedAll: Bool? = nil
+  var consentedToAny: Bool? = nil
+  var granularStatus: HostAPIGranularStatus? = nil
+  var hasConsentData: Bool? = nil
+  var rejectedAny: Bool? = nil
+  var rejectedLI: Bool? = nil
+  var legalBasisChanges: Bool? = nil
+  var vendorListAdditions: Bool? = nil
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIConsentStatus? {
@@ -470,9 +437,8 @@ struct HostAPIConsentStatus: Hashable {
       vendorListAdditions: vendorListAdditions
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       consentedAll,
       consentedToAny,
       granularStatus,
@@ -483,28 +449,11 @@ struct HostAPIConsentStatus: Hashable {
       vendorListAdditions,
     ]
   }
-
   static func == (lhs: HostAPIConsentStatus, rhs: HostAPIConsentStatus) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.consentedAll, rhs.consentedAll) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.consentedToAny,
-        rhs.consentedToAny
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.granularStatus, rhs.granularStatus) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.hasConsentData,
-        rhs.hasConsentData
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedAny, rhs.rejectedAny) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.rejectedLI,
-        rhs.rejectedLI
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.legalBasisChanges, rhs.legalBasisChanges) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.vendorListAdditions,
-        rhs.vendorListAdditions
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.consentedAll, rhs.consentedAll) && deepEqualsSourcepointUnifiedCmp(lhs.consentedToAny, rhs.consentedToAny) && deepEqualsSourcepointUnifiedCmp(lhs.granularStatus, rhs.granularStatus) && deepEqualsSourcepointUnifiedCmp(lhs.hasConsentData, rhs.hasConsentData) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedAny, rhs.rejectedAny) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedLI, rhs.rejectedLI) && deepEqualsSourcepointUnifiedCmp(lhs.legalBasisChanges, rhs.legalBasisChanges) && deepEqualsSourcepointUnifiedCmp(lhs.vendorListAdditions, rhs.vendorListAdditions)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -522,13 +471,14 @@ struct HostAPIConsentStatus: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPIGDPRConsent: Hashable {
-  var uuid: String?
-  var tcData: [String?: String?]?
-  var grants: [String?: HostAPIGDPRPurposeGrants?]?
+  var uuid: String? = nil
+  var tcData: [String?: String?]? = nil
+  var grants: [String?: HostAPIGDPRPurposeGrants?]? = nil
   var euconsent: String
-  var acceptedCategories: [String?]?
+  var acceptedCategories: [String?]? = nil
   var apply: Bool
-  var consentStatus: HostAPIConsentStatus?
+  var consentStatus: HostAPIConsentStatus? = nil
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPIGDPRConsent? {
@@ -550,9 +500,8 @@ struct HostAPIGDPRConsent: Hashable {
       consentStatus: consentStatus
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       uuid,
       tcData,
       grants,
@@ -562,22 +511,11 @@ struct HostAPIGDPRConsent: Hashable {
       consentStatus,
     ]
   }
-
   static func == (lhs: HostAPIGDPRConsent, rhs: HostAPIGDPRConsent) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(
-      lhs.tcData,
-      rhs.tcData
-    ) && deepEqualsSourcepointUnifiedCmp(lhs.grants, rhs.grants) && deepEqualsSourcepointUnifiedCmp(
-      lhs.euconsent,
-      rhs.euconsent
-    ) && deepEqualsSourcepointUnifiedCmp(lhs.acceptedCategories, rhs.acceptedCategories) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.apply,
-        rhs.apply
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.consentStatus, rhs.consentStatus)
+    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(lhs.tcData, rhs.tcData) && deepEqualsSourcepointUnifiedCmp(lhs.grants, rhs.grants) && deepEqualsSourcepointUnifiedCmp(lhs.euconsent, rhs.euconsent) && deepEqualsSourcepointUnifiedCmp(lhs.acceptedCategories, rhs.acceptedCategories) && deepEqualsSourcepointUnifiedCmp(lhs.apply, rhs.apply) && deepEqualsSourcepointUnifiedCmp(lhs.consentStatus, rhs.consentStatus)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -594,12 +532,13 @@ struct HostAPIGDPRConsent: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPICCPAConsent: Hashable {
-  var uuid: String?
-  var rejectedCategories: [String?]?
-  var rejectedVendors: [String?]?
-  var status: String?
+  var uuid: String? = nil
+  var rejectedCategories: [String?]? = nil
+  var rejectedVendors: [String?]? = nil
+  var status: String? = nil
   var uspstring: String
   var apply: Bool
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPICCPAConsent? {
@@ -619,9 +558,8 @@ struct HostAPICCPAConsent: Hashable {
       apply: apply
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       uuid,
       rejectedCategories,
       rejectedVendors,
@@ -630,23 +568,11 @@ struct HostAPICCPAConsent: Hashable {
       apply,
     ]
   }
-
   static func == (lhs: HostAPICCPAConsent, rhs: HostAPICCPAConsent) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(
-      lhs.rejectedCategories,
-      rhs.rejectedCategories
-    ) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedVendors, rhs.rejectedVendors) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.status,
-        rhs.status
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.uspstring, rhs.uspstring) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.apply,
-        rhs.apply
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.uuid, rhs.uuid) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedCategories, rhs.rejectedCategories) && deepEqualsSourcepointUnifiedCmp(lhs.rejectedVendors, rhs.rejectedVendors) && deepEqualsSourcepointUnifiedCmp(lhs.status, rhs.status) && deepEqualsSourcepointUnifiedCmp(lhs.uspstring, rhs.uspstring) && deepEqualsSourcepointUnifiedCmp(lhs.apply, rhs.apply)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -662,9 +588,10 @@ struct HostAPICCPAConsent: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct HostAPISPConsent: Hashable {
-  var gdpr: HostAPIGDPRConsent?
-  var ccpa: HostAPICCPAConsent?
-  var webConsents: String?
+  var gdpr: HostAPIGDPRConsent? = nil
+  var ccpa: HostAPICCPAConsent? = nil
+  var webConsents: String? = nil
+
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> HostAPISPConsent? {
@@ -678,23 +605,18 @@ struct HostAPISPConsent: Hashable {
       webConsents: webConsents
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       gdpr,
       ccpa,
       webConsents,
     ]
   }
-
   static func == (lhs: HostAPISPConsent, rhs: HostAPISPConsent) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.gdpr, rhs.gdpr) && deepEqualsSourcepointUnifiedCmp(
-      lhs.ccpa,
-      rhs.ccpa
-    ) && deepEqualsSourcepointUnifiedCmp(lhs.webConsents, rhs.webConsents)
+    return deepEqualsSourcepointUnifiedCmp(lhs.gdpr, rhs.gdpr) && deepEqualsSourcepointUnifiedCmp(lhs.ccpa, rhs.ccpa) && deepEqualsSourcepointUnifiedCmp(lhs.webConsents, rhs.webConsents)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -712,6 +634,7 @@ struct SPConfig: Hashable {
   var propertyName: String
   var pmId: String
 
+
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> SPConfig? {
     let accountId = pigeonVar_list[0] as! Int64
@@ -726,29 +649,19 @@ struct SPConfig: Hashable {
       pmId: pmId
     )
   }
-
   func toList() -> [Any?] {
-    [
+    return [
       accountId,
       propertyId,
       propertyName,
       pmId,
     ]
   }
-
   static func == (lhs: SPConfig, rhs: SPConfig) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsSourcepointUnifiedCmp(lhs.accountId, rhs.accountId) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.propertyId,
-        rhs.propertyId
-      ) && deepEqualsSourcepointUnifiedCmp(lhs.propertyName, rhs.propertyName) &&
-      deepEqualsSourcepointUnifiedCmp(
-        lhs.pmId,
-        rhs.pmId
-      )
+    return deepEqualsSourcepointUnifiedCmp(lhs.accountId, rhs.accountId) && deepEqualsSourcepointUnifiedCmp(lhs.propertyId, rhs.propertyId) && deepEqualsSourcepointUnifiedCmp(lhs.propertyName, rhs.propertyName) && deepEqualsSourcepointUnifiedCmp(lhs.pmId, rhs.pmId)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -764,65 +677,65 @@ private class SourcepointUnifiedCmpPigeonCodecReader: FlutterStandardReader {
   override func readValue(ofType type: UInt8) -> Any? {
     switch type {
     case 129:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPIPMTab(rawValue: enumResultAsInt)
       }
       return nil
     case 130:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPICampaignType(rawValue: enumResultAsInt)
       }
       return nil
     case 131:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPIMessageType(rawValue: enumResultAsInt)
       }
       return nil
     case 132:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPIGranularState(rawValue: enumResultAsInt)
       }
       return nil
     case 133:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPIActionType(rawValue: enumResultAsInt)
       }
       return nil
     case 134:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPIMessageLanguage(rawValue: enumResultAsInt)
       }
       return nil
     case 135:
-      let enumResultAsInt: Int? = nilOrValue(readValue() as! Int?)
-      if let enumResultAsInt {
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
         return HostAPICampaignsEnv(rawValue: enumResultAsInt)
       }
       return nil
     case 136:
-      return HostAPISPError.fromList(readValue() as! [Any?])
+      return HostAPISPError.fromList(self.readValue() as! [Any?])
     case 137:
-      return HostAPIConsentAction.fromList(readValue() as! [Any?])
+      return HostAPIConsentAction.fromList(self.readValue() as! [Any?])
     case 138:
-      return HostAPIGDPRPurposeGrants.fromList(readValue() as! [Any?])
+      return HostAPIGDPRPurposeGrants.fromList(self.readValue() as! [Any?])
     case 139:
-      return HostAPIGranularStatus.fromList(readValue() as! [Any?])
+      return HostAPIGranularStatus.fromList(self.readValue() as! [Any?])
     case 140:
-      return HostAPIConsentStatus.fromList(readValue() as! [Any?])
+      return HostAPIConsentStatus.fromList(self.readValue() as! [Any?])
     case 141:
-      return HostAPIGDPRConsent.fromList(readValue() as! [Any?])
+      return HostAPIGDPRConsent.fromList(self.readValue() as! [Any?])
     case 142:
-      return HostAPICCPAConsent.fromList(readValue() as! [Any?])
+      return HostAPICCPAConsent.fromList(self.readValue() as! [Any?])
     case 143:
-      return HostAPISPConsent.fromList(readValue() as! [Any?])
+      return HostAPISPConsent.fromList(self.readValue() as! [Any?])
     case 144:
-      return SPConfig.fromList(readValue() as! [Any?])
+      return SPConfig.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
     }
@@ -887,47 +800,35 @@ private class SourcepointUnifiedCmpPigeonCodecWriter: FlutterStandardWriter {
 
 private class SourcepointUnifiedCmpPigeonCodecReaderWriter: FlutterStandardReaderWriter {
   override func reader(with data: Data) -> FlutterStandardReader {
-    SourcepointUnifiedCmpPigeonCodecReader(data: data)
+    return SourcepointUnifiedCmpPigeonCodecReader(data: data)
   }
 
   override func writer(with data: NSMutableData) -> FlutterStandardWriter {
-    SourcepointUnifiedCmpPigeonCodecWriter(data: data)
+    return SourcepointUnifiedCmpPigeonCodecWriter(data: data)
   }
 }
 
 class SourcepointUnifiedCmpPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
-  static let shared =
-    SourcepointUnifiedCmpPigeonCodec(readerWriter: SourcepointUnifiedCmpPigeonCodecReaderWriter())
+  static let shared = SourcepointUnifiedCmpPigeonCodec(readerWriter: SourcepointUnifiedCmpPigeonCodecReaderWriter())
 }
+
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol SourcepointUnifiedCmpHostApi {
-  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId: String,
-                   messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
-                   messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
-                   completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
-  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
-                          messageType: HostAPIMessageType,
-                          completion: @escaping (Result<Void, Error>) -> Void)
+  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId: String, messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv, messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool, completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
+  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType, messageType: HostAPIMessageType, completion: @escaping (Result<Void, Error>) -> Void)
+  func customConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String], completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
+  func deleteCustomConsentGDPR(vendors: [String], categories: [String], legIntCategories: [String], completion: @escaping (Result<HostAPISPConsent, Error>) -> Void)
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class SourcepointUnifiedCmpHostApiSetup {
-  static var codec: FlutterStandardMessageCodec {
-    SourcepointUnifiedCmpPigeonCodec.shared
-  }
-
-  /// Sets up an instance of `SourcepointUnifiedCmpHostApi` to handle messages through the
-  /// `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: SourcepointUnifiedCmpHostApi?,
-                    messageChannelSuffix: String = "") {
+  static var codec: FlutterStandardMessageCodec { SourcepointUnifiedCmpPigeonCodec.shared }
+  /// Sets up an instance of `SourcepointUnifiedCmpHostApi` to handle messages through the `binaryMessenger`.
+  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: SourcepointUnifiedCmpHostApi?, messageChannelSuffix: String = "") {
     let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    let loadMessageChannel = FlutterBasicMessageChannel(
-      name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+    let loadMessageChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       loadMessageChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let accountIdArg = args[0] as! Int64
@@ -939,21 +840,11 @@ class SourcepointUnifiedCmpHostApiSetup {
         let messageTimeoutArg = args[6] as! Int64
         let runGDPRCampaignArg = args[7] as! Bool
         let runCCPACampaignArg = args[8] as! Bool
-        api.loadMessage(
-          accountId: accountIdArg,
-          propertyId: propertyIdArg,
-          propertyName: propertyNameArg,
-          pmId: pmIdArg,
-          messageLanguage: messageLanguageArg,
-          campaignsEnv: campaignsEnvArg,
-          messageTimeout: messageTimeoutArg,
-          runGDPRCampaign: runGDPRCampaignArg,
-          runCCPACampaign: runCCPACampaignArg
-        ) { result in
+        api.loadMessage(accountId: accountIdArg, propertyId: propertyIdArg, propertyName: propertyNameArg, pmId: pmIdArg, messageLanguage: messageLanguageArg, campaignsEnv: campaignsEnvArg, messageTimeout: messageTimeoutArg, runGDPRCampaign: runGDPRCampaignArg, runCCPACampaign: runCCPACampaignArg) { result in
           switch result {
-          case let .success(res):
+          case .success(let res):
             reply(wrapResult(res))
-          case let .failure(error):
+          case .failure(let error):
             reply(wrapError(error))
           }
         }
@@ -961,28 +852,19 @@ class SourcepointUnifiedCmpHostApiSetup {
     } else {
       loadMessageChannel.setMessageHandler(nil)
     }
-    let loadPrivacyManagerChannel = FlutterBasicMessageChannel(
-      name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager\(channelSuffix)",
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
-    if let api {
+    let loadPrivacyManagerChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
       loadPrivacyManagerChannel.setMessageHandler { message, reply in
         let args = message as! [Any?]
         let pmIdArg = args[0] as! String
         let pmTabArg = args[1] as! HostAPIPMTab
         let campaignTypeArg = args[2] as! HostAPICampaignType
         let messageTypeArg = args[3] as! HostAPIMessageType
-        api.loadPrivacyManager(
-          pmId: pmIdArg,
-          pmTab: pmTabArg,
-          campaignType: campaignTypeArg,
-          messageType: messageTypeArg
-        ) { result in
+        api.loadPrivacyManager(pmId: pmIdArg, pmTab: pmTabArg, campaignType: campaignTypeArg, messageType: messageTypeArg) { result in
           switch result {
           case .success:
             reply(wrapResult(nil))
-          case let .failure(error):
+          case .failure(let error):
             reply(wrapError(error))
           }
         }
@@ -990,25 +872,56 @@ class SourcepointUnifiedCmpHostApiSetup {
     } else {
       loadPrivacyManagerChannel.setMessageHandler(nil)
     }
+    let customConsentGDPRChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.customConsentGDPR\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      customConsentGDPRChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let vendorsArg = args[0] as! [String]
+        let categoriesArg = args[1] as! [String]
+        let legIntCategoriesArg = args[2] as! [String]
+        api.customConsentGDPR(vendors: vendorsArg, categories: categoriesArg, legIntCategories: legIntCategoriesArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      customConsentGDPRChannel.setMessageHandler(nil)
+    }
+    let deleteCustomConsentGDPRChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      deleteCustomConsentGDPRChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let vendorsArg = args[0] as! [String]
+        let categoriesArg = args[1] as! [String]
+        let legIntCategoriesArg = args[2] as! [String]
+        api.deleteCustomConsentGDPR(vendors: vendorsArg, categories: categoriesArg, legIntCategories: legIntCategoriesArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      deleteCustomConsentGDPRChannel.setMessageHandler(nil)
+    }
   }
 }
-
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol SourcepointUnifiedCmpFlutterApiProtocol {
   func onUIFinished(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
   func onUIReady(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onError(error errorArg: HostAPISPError,
-               completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onConsentReady(consent consentArg: HostAPISPConsent,
-                      completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onAction(consentAction consentActionArg: HostAPIConsentAction,
-                completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onNoIntentActivitiesFound(url urlArg: String,
-                                 completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
-  func onSpFinished(consent consentArg: HostAPISPConsent,
-                    completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onError(error errorArg: HostAPISPError, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onConsentReady(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onAction(consentAction consentActionArg: HostAPIConsentAction, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onNoIntentActivitiesFound(url urlArg: String, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
+  func onSpFinished(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void)
 }
-
 class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
   private let binaryMessenger: FlutterBinaryMessenger
   private let messageChannelSuffix: String
@@ -1016,18 +929,12 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
     self.binaryMessenger = binaryMessenger
     self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
   }
-
   var codec: SourcepointUnifiedCmpPigeonCodec {
-    SourcepointUnifiedCmpPigeonCodec.shared
+    return SourcepointUnifiedCmpPigeonCodec.shared
   }
-
   func onUIFinished(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage(nil) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1043,14 +950,9 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-
   func onUIReady(completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage(nil) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1066,15 +968,9 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-
-  func onError(error errorArg: HostAPISPError,
-               completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+  func onError(error errorArg: HostAPISPError, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([errorArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1090,15 +986,9 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-
-  func onConsentReady(consent consentArg: HostAPISPConsent,
-                      completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+  func onConsentReady(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([consentArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1114,15 +1004,9 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-
-  func onAction(consentAction consentActionArg: HostAPIConsentAction,
-                completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+  func onAction(consentAction consentActionArg: HostAPIConsentAction, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([consentActionArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1138,16 +1022,9 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-
-  func onNoIntentActivitiesFound(url urlArg: String,
-                                 completion: @escaping (Result<Void, HostApiFlutterError>)
-                                   -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+  func onNoIntentActivitiesFound(url urlArg: String, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([urlArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))
@@ -1163,15 +1040,9 @@ class SourcepointUnifiedCmpFlutterApi: SourcepointUnifiedCmpFlutterApiProtocol {
       }
     }
   }
-
-  func onSpFinished(consent consentArg: HostAPISPConsent,
-                    completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
-    let channelName = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(
-      name: channelName,
-      binaryMessenger: binaryMessenger,
-      codec: codec
-    )
+  func onSpFinished(consent consentArg: HostAPISPConsent, completion: @escaping (Result<Void, HostApiFlutterError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
     channel.sendMessage([consentArg] as [Any?]) { response in
       guard let listResponse = response as? [Any?] else {
         completion(.failure(createConnectionError(withChannelName: channelName)))

--- a/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
@@ -284,6 +284,34 @@ class SourcepointUnifiedCmpIOS extends SourcepointUnifiedCmpPlatform {
   }
 
   @override
+  Future<SPConsent> customConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final hostConsent = await _api.customConsentGDPR(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories,
+    );
+    return hostConsent.toSPConsent();
+  }
+
+  @override
+  Future<SPConsent> deleteCustomConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final hostConsent = await _api.deleteCustomConsentGDPR(
+      vendors: vendors,
+      categories: categories,
+      legIntCategories: legIntCategories,
+    );
+    return hostConsent.toSPConsent();
+  }
+
+  @override
   void registerConsentChangeNotifier(ConsentChangeNotifier notifier) {
     assert(_notifier == null, 'ConsentChangeNotifier already set');
     messages.SourcepointUnifiedCmpFlutterApi.setUp(

--- a/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
@@ -10,9 +10,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-    List<Object?>? replyList,
-    String channelName, {
-    required bool isNullValid,
+  List<Object?>? replyList,
+  String channelName, {
+  required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -34,8 +34,11 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-
-List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({
+  Object? result,
+  PlatformException? error,
+  bool empty = false,
+}) {
   if (empty) {
     return <Object?>[];
   }
@@ -44,6 +47,7 @@ List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty
   }
   return <Object?>[error.code, error.message, error.details];
 }
+
 bool _deepEquals(Object? a, Object? b) {
   if (identical(a, b)) {
     return true;
@@ -56,8 +60,9 @@ bool _deepEquals(Object? a, Object? b) {
   }
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed
-            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
+        a.indexed.every(
+          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
+        );
   }
   if (a is Map && b is Map) {
     if (a.length != b.length) {
@@ -106,30 +111,13 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
+enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPIPMTab {
-  defaults,
-  purposes,
-  vendors,
-  features,
-}
+enum HostAPICampaignType { gdpr, ccpa }
 
-enum HostAPICampaignType {
-  gdpr,
-  ccpa,
-}
+enum HostAPIMessageType { mobile, ott, legacyOtt }
 
-enum HostAPIMessageType {
-  mobile,
-  ott,
-  legacyOtt,
-}
-
-enum HostAPIGranularState {
-  all,
-  some,
-  none,
-}
+enum HostAPIGranularState { all, some, none }
 
 enum HostAPIActionType {
   showOptions,
@@ -144,39 +132,24 @@ enum HostAPIActionType {
   unknown,
 }
 
-enum HostAPIMessageLanguage {
-  english,
-  french,
-  german,
-  italian,
-  spanish,
-  dutch,
-}
+enum HostAPIMessageLanguage { english, french, german, italian, spanish, dutch }
 
-enum HostAPICampaignsEnv {
-  stage,
-  publicEnv,
-}
+enum HostAPICampaignsEnv { stage, publicEnv }
 
 class HostAPISPError {
-  HostAPISPError({
-    required this.spCode,
-    required this.description,
-  });
+  HostAPISPError({required this.spCode, required this.description});
 
   String spCode;
 
   String description;
 
   List<Object?> _toList() {
-    return <Object?>[
-      spCode,
-      description,
-    ];
+    return <Object?>[spCode, description];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPISPError decode(Object result) {
     result as List<Object?>;
@@ -195,7 +168,8 @@ class HostAPISPError {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(spCode, other.spCode) && _deepEquals(description, other.description);
+    return _deepEquals(spCode, other.spCode) &&
+        _deepEquals(description, other.description);
   }
 
   @override
@@ -220,16 +194,12 @@ class HostAPIConsentAction {
   String? customActionId;
 
   List<Object?> _toList() {
-    return <Object?>[
-      actionType,
-      pubData,
-      campaignType,
-      customActionId,
-    ];
+    return <Object?>[actionType, pubData, campaignType, customActionId];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIConsentAction decode(Object result) {
     result as List<Object?>;
@@ -250,7 +220,10 @@ class HostAPIConsentAction {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(actionType, other.actionType) && _deepEquals(pubData, other.pubData) && _deepEquals(campaignType, other.campaignType) && _deepEquals(customActionId, other.customActionId);
+    return _deepEquals(actionType, other.actionType) &&
+        _deepEquals(pubData, other.pubData) &&
+        _deepEquals(campaignType, other.campaignType) &&
+        _deepEquals(customActionId, other.customActionId);
   }
 
   @override
@@ -259,43 +232,41 @@ class HostAPIConsentAction {
 }
 
 class HostAPIGDPRPurposeGrants {
-  HostAPIGDPRPurposeGrants({
-    required this.granted,
-    this.purposeGrants,
-  });
+  HostAPIGDPRPurposeGrants({required this.granted, this.purposeGrants});
 
   bool granted;
 
   Map<String?, bool?>? purposeGrants;
 
   List<Object?> _toList() {
-    return <Object?>[
-      granted,
-      purposeGrants,
-    ];
+    return <Object?>[granted, purposeGrants];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIGDPRPurposeGrants decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRPurposeGrants(
       granted: result[0]! as bool,
-      purposeGrants: (result[1] as Map<Object?, Object?>?)?.cast<String?, bool?>(),
+      purposeGrants: (result[1] as Map<Object?, Object?>?)
+          ?.cast<String?, bool?>(),
     );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! HostAPIGDPRPurposeGrants || other.runtimeType != runtimeType) {
+    if (other is! HostAPIGDPRPurposeGrants ||
+        other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(granted, other.granted) && _deepEquals(purposeGrants, other.purposeGrants);
+    return _deepEquals(granted, other.granted) &&
+        _deepEquals(purposeGrants, other.purposeGrants);
   }
 
   @override
@@ -337,7 +308,8 @@ class HostAPIGranularStatus {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIGranularStatus decode(Object result) {
     result as List<Object?>;
@@ -360,7 +332,12 @@ class HostAPIGranularStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(defaultConsent, other.defaultConsent) && _deepEquals(previousOptInAll, other.previousOptInAll) && _deepEquals(purposeConsent, other.purposeConsent) && _deepEquals(purposeLegInt, other.purposeLegInt) && _deepEquals(vendorConsent, other.vendorConsent) && _deepEquals(vendorLegInt, other.vendorLegInt);
+    return _deepEquals(defaultConsent, other.defaultConsent) &&
+        _deepEquals(previousOptInAll, other.previousOptInAll) &&
+        _deepEquals(purposeConsent, other.purposeConsent) &&
+        _deepEquals(purposeLegInt, other.purposeLegInt) &&
+        _deepEquals(vendorConsent, other.vendorConsent) &&
+        _deepEquals(vendorLegInt, other.vendorLegInt);
   }
 
   @override
@@ -410,7 +387,8 @@ class HostAPIConsentStatus {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIConsentStatus decode(Object result) {
     result as List<Object?>;
@@ -435,7 +413,14 @@ class HostAPIConsentStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(consentedAll, other.consentedAll) && _deepEquals(consentedToAny, other.consentedToAny) && _deepEquals(granularStatus, other.granularStatus) && _deepEquals(hasConsentData, other.hasConsentData) && _deepEquals(rejectedAny, other.rejectedAny) && _deepEquals(rejectedLI, other.rejectedLI) && _deepEquals(legalBasisChanges, other.legalBasisChanges) && _deepEquals(vendorListAdditions, other.vendorListAdditions);
+    return _deepEquals(consentedAll, other.consentedAll) &&
+        _deepEquals(consentedToAny, other.consentedToAny) &&
+        _deepEquals(granularStatus, other.granularStatus) &&
+        _deepEquals(hasConsentData, other.hasConsentData) &&
+        _deepEquals(rejectedAny, other.rejectedAny) &&
+        _deepEquals(rejectedLI, other.rejectedLI) &&
+        _deepEquals(legalBasisChanges, other.legalBasisChanges) &&
+        _deepEquals(vendorListAdditions, other.vendorListAdditions);
   }
 
   @override
@@ -481,14 +466,16 @@ class HostAPIGDPRConsent {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPIGDPRConsent decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRConsent(
       uuid: result[0] as String?,
       tcData: (result[1] as Map<Object?, Object?>?)?.cast<String?, String?>(),
-      grants: (result[2] as Map<Object?, Object?>?)?.cast<String?, HostAPIGDPRPurposeGrants?>(),
+      grants: (result[2] as Map<Object?, Object?>?)
+          ?.cast<String?, HostAPIGDPRPurposeGrants?>(),
       euconsent: result[3]! as String,
       acceptedCategories: (result[4] as List<Object?>?)?.cast<String?>(),
       apply: result[5]! as bool,
@@ -505,7 +492,13 @@ class HostAPIGDPRConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) && _deepEquals(tcData, other.tcData) && _deepEquals(grants, other.grants) && _deepEquals(euconsent, other.euconsent) && _deepEquals(acceptedCategories, other.acceptedCategories) && _deepEquals(apply, other.apply) && _deepEquals(consentStatus, other.consentStatus);
+    return _deepEquals(uuid, other.uuid) &&
+        _deepEquals(tcData, other.tcData) &&
+        _deepEquals(grants, other.grants) &&
+        _deepEquals(euconsent, other.euconsent) &&
+        _deepEquals(acceptedCategories, other.acceptedCategories) &&
+        _deepEquals(apply, other.apply) &&
+        _deepEquals(consentStatus, other.consentStatus);
   }
 
   @override
@@ -547,7 +540,8 @@ class HostAPICCPAConsent {
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPICCPAConsent decode(Object result) {
     result as List<Object?>;
@@ -570,7 +564,12 @@ class HostAPICCPAConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) && _deepEquals(rejectedCategories, other.rejectedCategories) && _deepEquals(rejectedVendors, other.rejectedVendors) && _deepEquals(status, other.status) && _deepEquals(uspstring, other.uspstring) && _deepEquals(apply, other.apply);
+    return _deepEquals(uuid, other.uuid) &&
+        _deepEquals(rejectedCategories, other.rejectedCategories) &&
+        _deepEquals(rejectedVendors, other.rejectedVendors) &&
+        _deepEquals(status, other.status) &&
+        _deepEquals(uspstring, other.uspstring) &&
+        _deepEquals(apply, other.apply);
   }
 
   @override
@@ -579,11 +578,7 @@ class HostAPICCPAConsent {
 }
 
 class HostAPISPConsent {
-  HostAPISPConsent({
-    this.gdpr,
-    this.ccpa,
-    this.webConsents,
-  });
+  HostAPISPConsent({this.gdpr, this.ccpa, this.webConsents});
 
   HostAPIGDPRConsent? gdpr;
 
@@ -592,15 +587,12 @@ class HostAPISPConsent {
   String? webConsents;
 
   List<Object?> _toList() {
-    return <Object?>[
-      gdpr,
-      ccpa,
-      webConsents,
-    ];
+    return <Object?>[gdpr, ccpa, webConsents];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static HostAPISPConsent decode(Object result) {
     result as List<Object?>;
@@ -620,7 +612,9 @@ class HostAPISPConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(gdpr, other.gdpr) && _deepEquals(ccpa, other.ccpa) && _deepEquals(webConsents, other.webConsents);
+    return _deepEquals(gdpr, other.gdpr) &&
+        _deepEquals(ccpa, other.ccpa) &&
+        _deepEquals(webConsents, other.webConsents);
   }
 
   @override
@@ -645,16 +639,12 @@ class SPConfig {
   String pmId;
 
   List<Object?> _toList() {
-    return <Object?>[
-      accountId,
-      propertyId,
-      propertyName,
-      pmId,
-    ];
+    return <Object?>[accountId, propertyId, propertyName, pmId];
   }
 
   Object encode() {
-    return _toList();  }
+    return _toList();
+  }
 
   static SPConfig decode(Object result) {
     result as List<Object?>;
@@ -675,14 +665,16 @@ class SPConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(accountId, other.accountId) && _deepEquals(propertyId, other.propertyId) && _deepEquals(propertyName, other.propertyName) && _deepEquals(pmId, other.pmId);
+    return _deepEquals(accountId, other.accountId) &&
+        _deepEquals(propertyId, other.propertyId) &&
+        _deepEquals(propertyName, other.propertyName) &&
+        _deepEquals(pmId, other.pmId);
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
-
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -691,52 +683,52 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    }    else if (value is HostAPIPMTab) {
+    } else if (value is HostAPIPMTab) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPICampaignType) {
+    } else if (value is HostAPICampaignType) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIMessageType) {
+    } else if (value is HostAPIMessageType) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIGranularState) {
+    } else if (value is HostAPIGranularState) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIActionType) {
+    } else if (value is HostAPIActionType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPIMessageLanguage) {
+    } else if (value is HostAPIMessageLanguage) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPICampaignsEnv) {
+    } else if (value is HostAPICampaignsEnv) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    }    else if (value is HostAPISPError) {
+    } else if (value is HostAPISPError) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIConsentAction) {
+    } else if (value is HostAPIConsentAction) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIGDPRPurposeGrants) {
+    } else if (value is HostAPIGDPRPurposeGrants) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIGranularStatus) {
+    } else if (value is HostAPIGranularStatus) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIConsentStatus) {
+    } else if (value is HostAPIConsentStatus) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPIGDPRConsent) {
+    } else if (value is HostAPIGDPRConsent) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPICCPAConsent) {
+    } else if (value is HostAPICCPAConsent) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    }    else if (value is HostAPISPConsent) {
+    } else if (value is HostAPISPConsent) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    }    else if (value is SPConfig) {
+    } else if (value is SPConfig) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else {
@@ -796,87 +788,131 @@ class SourcepointUnifiedCmpHostApi {
   /// Constructor for [SourcepointUnifiedCmpHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  SourcepointUnifiedCmpHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
-      : pigeonVar_binaryMessenger = binaryMessenger,
-        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  SourcepointUnifiedCmpHostApi({
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) : pigeonVar_binaryMessenger = binaryMessenger,
+       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
+           ? '.$messageChannelSuffix'
+           : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<HostAPISPConsent> loadMessage({required int accountId, required int propertyId, required String propertyName, required String pmId, required HostAPIMessageLanguage messageLanguage, required HostAPICampaignsEnv campaignsEnv, required int messageTimeout, required bool runGDPRCampaign, required bool runCCPACampaign, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> loadMessage({
+    required int accountId,
+    required int propertyId,
+    required String propertyName,
+    required String pmId,
+    required HostAPIMessageLanguage messageLanguage,
+    required HostAPICampaignsEnv campaignsEnv,
+    required int messageTimeout,
+    required bool runGDPRCampaign,
+    required bool runCCPACampaign,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[accountId, propertyId, propertyName, pmId, messageLanguage, campaignsEnv, messageTimeout, runGDPRCampaign, runCCPACampaign]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[
+          accountId,
+          propertyId,
+          propertyName,
+          pmId,
+          messageLanguage,
+          campaignsEnv,
+          messageTimeout,
+          runGDPRCampaign,
+          runCCPACampaign,
+        ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 
-  Future<void> loadPrivacyManager({required String pmId, required HostAPIPMTab pmTab, required HostAPICampaignType campaignType, required HostAPIMessageType messageType, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
+  Future<void> loadPrivacyManager({
+    required String pmId,
+    required HostAPIPMTab pmTab,
+    required HostAPICampaignType campaignType,
+    required HostAPIMessageType messageType,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[pmId, pmTab, campaignType, messageType]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[pmId, pmTab, campaignType, messageType],
+    );
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: true,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: true,
+    );
   }
 
-  Future<HostAPISPConsent> customConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.customConsentGDPR$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> customConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.customConsentGDPR$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[vendors, categories, legIntCategories],
+    );
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 
-  Future<HostAPISPConsent> deleteCustomConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
-    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> deleteCustomConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) async {
+    final pigeonVar_channelName =
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
+      <Object?>[vendors, categories, legIntCategories],
+    );
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-        pigeonVar_replyList,
-        pigeonVar_channelName,
-        isNullValid: false,
-    )
-    ;
+      pigeonVar_replyList,
+      pigeonVar_channelName,
+      isNullValid: false,
+    );
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 }
@@ -898,12 +934,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
 
   void onSpFinished(HostAPISPConsent consent);
 
-  static void setUp(SourcepointUnifiedCmpFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(
+    SourcepointUnifiedCmpFlutterApi? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty
+        ? '.$messageChannelSuffix'
+        : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -913,16 +957,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -932,16 +980,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -953,16 +1005,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -974,37 +1030,46 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final HostAPIConsentAction arg_consentAction = args[0]! as HostAPIConsentAction;
+          final HostAPIConsentAction arg_consentAction =
+              args[0]! as HostAPIConsentAction;
           try {
             api.onAction(arg_consentAction);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1016,16 +1081,20 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix', pigeonChannelCodec,
-          binaryMessenger: binaryMessenger);
+        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix',
+        pigeonChannelCodec,
+        binaryMessenger: binaryMessenger,
+      );
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1037,8 +1106,10 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+              error: PlatformException(code: 'error', message: e.toString()),
+            );
           }
         });
       }

--- a/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
@@ -10,9 +10,9 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show immutable, protected, visibleForTesting;
 
 Object? _extractReplyValueOrThrow(
-  List<Object?>? replyList,
-  String channelName, {
-  required bool isNullValid,
+    List<Object?>? replyList,
+    String channelName, {
+    required bool isNullValid,
 }) {
   if (replyList == null) {
     throw PlatformException(
@@ -34,11 +34,8 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-List<Object?> wrapResponse({
-  Object? result,
-  PlatformException? error,
-  bool empty = false,
-}) {
+
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -47,7 +44,6 @@ List<Object?> wrapResponse({
   }
   return <Object?>[error.code, error.message, error.details];
 }
-
 bool _deepEquals(Object? a, Object? b) {
   if (identical(a, b)) {
     return true;
@@ -60,9 +56,8 @@ bool _deepEquals(Object? a, Object? b) {
   }
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed.every(
-          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
-        );
+        a.indexed
+            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
     if (a.length != b.length) {
@@ -111,13 +106,30 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
-enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa }
+enum HostAPIPMTab {
+  defaults,
+  purposes,
+  vendors,
+  features,
+}
 
-enum HostAPIMessageType { mobile, ott, legacyOtt }
+enum HostAPICampaignType {
+  gdpr,
+  ccpa,
+}
 
-enum HostAPIGranularState { all, some, none }
+enum HostAPIMessageType {
+  mobile,
+  ott,
+  legacyOtt,
+}
+
+enum HostAPIGranularState {
+  all,
+  some,
+  none,
+}
 
 enum HostAPIActionType {
   showOptions,
@@ -132,24 +144,39 @@ enum HostAPIActionType {
   unknown,
 }
 
-enum HostAPIMessageLanguage { english, french, german, italian, spanish, dutch }
+enum HostAPIMessageLanguage {
+  english,
+  french,
+  german,
+  italian,
+  spanish,
+  dutch,
+}
 
-enum HostAPICampaignsEnv { stage, publicEnv }
+enum HostAPICampaignsEnv {
+  stage,
+  publicEnv,
+}
 
 class HostAPISPError {
-  HostAPISPError({required this.spCode, required this.description});
+  HostAPISPError({
+    required this.spCode,
+    required this.description,
+  });
 
   String spCode;
 
   String description;
 
   List<Object?> _toList() {
-    return <Object?>[spCode, description];
+    return <Object?>[
+      spCode,
+      description,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPISPError decode(Object result) {
     result as List<Object?>;
@@ -168,8 +195,7 @@ class HostAPISPError {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(spCode, other.spCode) &&
-        _deepEquals(description, other.description);
+    return _deepEquals(spCode, other.spCode) && _deepEquals(description, other.description);
   }
 
   @override
@@ -194,12 +220,16 @@ class HostAPIConsentAction {
   String? customActionId;
 
   List<Object?> _toList() {
-    return <Object?>[actionType, pubData, campaignType, customActionId];
+    return <Object?>[
+      actionType,
+      pubData,
+      campaignType,
+      customActionId,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIConsentAction decode(Object result) {
     result as List<Object?>;
@@ -220,10 +250,7 @@ class HostAPIConsentAction {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(actionType, other.actionType) &&
-        _deepEquals(pubData, other.pubData) &&
-        _deepEquals(campaignType, other.campaignType) &&
-        _deepEquals(customActionId, other.customActionId);
+    return _deepEquals(actionType, other.actionType) && _deepEquals(pubData, other.pubData) && _deepEquals(campaignType, other.campaignType) && _deepEquals(customActionId, other.customActionId);
   }
 
   @override
@@ -232,41 +259,43 @@ class HostAPIConsentAction {
 }
 
 class HostAPIGDPRPurposeGrants {
-  HostAPIGDPRPurposeGrants({required this.granted, this.purposeGrants});
+  HostAPIGDPRPurposeGrants({
+    required this.granted,
+    this.purposeGrants,
+  });
 
   bool granted;
 
   Map<String?, bool?>? purposeGrants;
 
   List<Object?> _toList() {
-    return <Object?>[granted, purposeGrants];
+    return <Object?>[
+      granted,
+      purposeGrants,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIGDPRPurposeGrants decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRPurposeGrants(
       granted: result[0]! as bool,
-      purposeGrants: (result[1] as Map<Object?, Object?>?)
-          ?.cast<String?, bool?>(),
+      purposeGrants: (result[1] as Map<Object?, Object?>?)?.cast<String?, bool?>(),
     );
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
-    if (other is! HostAPIGDPRPurposeGrants ||
-        other.runtimeType != runtimeType) {
+    if (other is! HostAPIGDPRPurposeGrants || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(granted, other.granted) &&
-        _deepEquals(purposeGrants, other.purposeGrants);
+    return _deepEquals(granted, other.granted) && _deepEquals(purposeGrants, other.purposeGrants);
   }
 
   @override
@@ -308,8 +337,7 @@ class HostAPIGranularStatus {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIGranularStatus decode(Object result) {
     result as List<Object?>;
@@ -332,12 +360,7 @@ class HostAPIGranularStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(defaultConsent, other.defaultConsent) &&
-        _deepEquals(previousOptInAll, other.previousOptInAll) &&
-        _deepEquals(purposeConsent, other.purposeConsent) &&
-        _deepEquals(purposeLegInt, other.purposeLegInt) &&
-        _deepEquals(vendorConsent, other.vendorConsent) &&
-        _deepEquals(vendorLegInt, other.vendorLegInt);
+    return _deepEquals(defaultConsent, other.defaultConsent) && _deepEquals(previousOptInAll, other.previousOptInAll) && _deepEquals(purposeConsent, other.purposeConsent) && _deepEquals(purposeLegInt, other.purposeLegInt) && _deepEquals(vendorConsent, other.vendorConsent) && _deepEquals(vendorLegInt, other.vendorLegInt);
   }
 
   @override
@@ -387,8 +410,7 @@ class HostAPIConsentStatus {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIConsentStatus decode(Object result) {
     result as List<Object?>;
@@ -413,14 +435,7 @@ class HostAPIConsentStatus {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(consentedAll, other.consentedAll) &&
-        _deepEquals(consentedToAny, other.consentedToAny) &&
-        _deepEquals(granularStatus, other.granularStatus) &&
-        _deepEquals(hasConsentData, other.hasConsentData) &&
-        _deepEquals(rejectedAny, other.rejectedAny) &&
-        _deepEquals(rejectedLI, other.rejectedLI) &&
-        _deepEquals(legalBasisChanges, other.legalBasisChanges) &&
-        _deepEquals(vendorListAdditions, other.vendorListAdditions);
+    return _deepEquals(consentedAll, other.consentedAll) && _deepEquals(consentedToAny, other.consentedToAny) && _deepEquals(granularStatus, other.granularStatus) && _deepEquals(hasConsentData, other.hasConsentData) && _deepEquals(rejectedAny, other.rejectedAny) && _deepEquals(rejectedLI, other.rejectedLI) && _deepEquals(legalBasisChanges, other.legalBasisChanges) && _deepEquals(vendorListAdditions, other.vendorListAdditions);
   }
 
   @override
@@ -466,16 +481,14 @@ class HostAPIGDPRConsent {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPIGDPRConsent decode(Object result) {
     result as List<Object?>;
     return HostAPIGDPRConsent(
       uuid: result[0] as String?,
       tcData: (result[1] as Map<Object?, Object?>?)?.cast<String?, String?>(),
-      grants: (result[2] as Map<Object?, Object?>?)
-          ?.cast<String?, HostAPIGDPRPurposeGrants?>(),
+      grants: (result[2] as Map<Object?, Object?>?)?.cast<String?, HostAPIGDPRPurposeGrants?>(),
       euconsent: result[3]! as String,
       acceptedCategories: (result[4] as List<Object?>?)?.cast<String?>(),
       apply: result[5]! as bool,
@@ -492,13 +505,7 @@ class HostAPIGDPRConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) &&
-        _deepEquals(tcData, other.tcData) &&
-        _deepEquals(grants, other.grants) &&
-        _deepEquals(euconsent, other.euconsent) &&
-        _deepEquals(acceptedCategories, other.acceptedCategories) &&
-        _deepEquals(apply, other.apply) &&
-        _deepEquals(consentStatus, other.consentStatus);
+    return _deepEquals(uuid, other.uuid) && _deepEquals(tcData, other.tcData) && _deepEquals(grants, other.grants) && _deepEquals(euconsent, other.euconsent) && _deepEquals(acceptedCategories, other.acceptedCategories) && _deepEquals(apply, other.apply) && _deepEquals(consentStatus, other.consentStatus);
   }
 
   @override
@@ -540,8 +547,7 @@ class HostAPICCPAConsent {
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPICCPAConsent decode(Object result) {
     result as List<Object?>;
@@ -564,12 +570,7 @@ class HostAPICCPAConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(uuid, other.uuid) &&
-        _deepEquals(rejectedCategories, other.rejectedCategories) &&
-        _deepEquals(rejectedVendors, other.rejectedVendors) &&
-        _deepEquals(status, other.status) &&
-        _deepEquals(uspstring, other.uspstring) &&
-        _deepEquals(apply, other.apply);
+    return _deepEquals(uuid, other.uuid) && _deepEquals(rejectedCategories, other.rejectedCategories) && _deepEquals(rejectedVendors, other.rejectedVendors) && _deepEquals(status, other.status) && _deepEquals(uspstring, other.uspstring) && _deepEquals(apply, other.apply);
   }
 
   @override
@@ -578,7 +579,11 @@ class HostAPICCPAConsent {
 }
 
 class HostAPISPConsent {
-  HostAPISPConsent({this.gdpr, this.ccpa, this.webConsents});
+  HostAPISPConsent({
+    this.gdpr,
+    this.ccpa,
+    this.webConsents,
+  });
 
   HostAPIGDPRConsent? gdpr;
 
@@ -587,12 +592,15 @@ class HostAPISPConsent {
   String? webConsents;
 
   List<Object?> _toList() {
-    return <Object?>[gdpr, ccpa, webConsents];
+    return <Object?>[
+      gdpr,
+      ccpa,
+      webConsents,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static HostAPISPConsent decode(Object result) {
     result as List<Object?>;
@@ -612,9 +620,7 @@ class HostAPISPConsent {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(gdpr, other.gdpr) &&
-        _deepEquals(ccpa, other.ccpa) &&
-        _deepEquals(webConsents, other.webConsents);
+    return _deepEquals(gdpr, other.gdpr) && _deepEquals(ccpa, other.ccpa) && _deepEquals(webConsents, other.webConsents);
   }
 
   @override
@@ -639,12 +645,16 @@ class SPConfig {
   String pmId;
 
   List<Object?> _toList() {
-    return <Object?>[accountId, propertyId, propertyName, pmId];
+    return <Object?>[
+      accountId,
+      propertyId,
+      propertyName,
+      pmId,
+    ];
   }
 
   Object encode() {
-    return _toList();
-  }
+    return _toList();  }
 
   static SPConfig decode(Object result) {
     result as List<Object?>;
@@ -665,16 +675,14 @@ class SPConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(accountId, other.accountId) &&
-        _deepEquals(propertyId, other.propertyId) &&
-        _deepEquals(propertyName, other.propertyName) &&
-        _deepEquals(pmId, other.pmId);
+    return _deepEquals(accountId, other.accountId) && _deepEquals(propertyId, other.propertyId) && _deepEquals(propertyName, other.propertyName) && _deepEquals(pmId, other.pmId);
   }
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
+
 
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
@@ -683,52 +691,52 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is int) {
       buffer.putUint8(4);
       buffer.putInt64(value);
-    } else if (value is HostAPIPMTab) {
+    }    else if (value is HostAPIPMTab) {
       buffer.putUint8(129);
       writeValue(buffer, value.index);
-    } else if (value is HostAPICampaignType) {
+    }    else if (value is HostAPICampaignType) {
       buffer.putUint8(130);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIMessageType) {
+    }    else if (value is HostAPIMessageType) {
       buffer.putUint8(131);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIGranularState) {
+    }    else if (value is HostAPIGranularState) {
       buffer.putUint8(132);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIActionType) {
+    }    else if (value is HostAPIActionType) {
       buffer.putUint8(133);
       writeValue(buffer, value.index);
-    } else if (value is HostAPIMessageLanguage) {
+    }    else if (value is HostAPIMessageLanguage) {
       buffer.putUint8(134);
       writeValue(buffer, value.index);
-    } else if (value is HostAPICampaignsEnv) {
+    }    else if (value is HostAPICampaignsEnv) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    } else if (value is HostAPISPError) {
+    }    else if (value is HostAPISPError) {
       buffer.putUint8(136);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIConsentAction) {
+    }    else if (value is HostAPIConsentAction) {
       buffer.putUint8(137);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIGDPRPurposeGrants) {
+    }    else if (value is HostAPIGDPRPurposeGrants) {
       buffer.putUint8(138);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIGranularStatus) {
+    }    else if (value is HostAPIGranularStatus) {
       buffer.putUint8(139);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIConsentStatus) {
+    }    else if (value is HostAPIConsentStatus) {
       buffer.putUint8(140);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPIGDPRConsent) {
+    }    else if (value is HostAPIGDPRConsent) {
       buffer.putUint8(141);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPICCPAConsent) {
+    }    else if (value is HostAPICCPAConsent) {
       buffer.putUint8(142);
       writeValue(buffer, value.encode());
-    } else if (value is HostAPISPConsent) {
+    }    else if (value is HostAPISPConsent) {
       buffer.putUint8(143);
       writeValue(buffer, value.encode());
-    } else if (value is SPConfig) {
+    }    else if (value is SPConfig) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
     } else {
@@ -788,82 +796,88 @@ class SourcepointUnifiedCmpHostApi {
   /// Constructor for [SourcepointUnifiedCmpHostApi].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  SourcepointUnifiedCmpHostApi({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  SourcepointUnifiedCmpHostApi({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   final String pigeonVar_messageChannelSuffix;
 
-  Future<HostAPISPConsent> loadMessage({
-    required int accountId,
-    required int propertyId,
-    required String propertyName,
-    required String pmId,
-    required HostAPIMessageLanguage messageLanguage,
-    required HostAPICampaignsEnv campaignsEnv,
-    required int messageTimeout,
-    required bool runGDPRCampaign,
-    required bool runCCPACampaign,
-  }) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
+  Future<HostAPISPConsent> loadMessage({required int accountId, required int propertyId, required String propertyName, required String pmId, required HostAPIMessageLanguage messageLanguage, required HostAPICampaignsEnv campaignsEnv, required int messageTimeout, required bool runGDPRCampaign, required bool runCCPACampaign, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadMessage$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
-        .send(<Object?>[
-          accountId,
-          propertyId,
-          propertyName,
-          pmId,
-          messageLanguage,
-          campaignsEnv,
-          messageTimeout,
-          runGDPRCampaign,
-          runCCPACampaign,
-        ]);
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[accountId, propertyId, propertyName, pmId, messageLanguage, campaignsEnv, messageTimeout, runGDPRCampaign, runCCPACampaign]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
-      pigeonVar_replyList,
-      pigeonVar_channelName,
-      isNullValid: false,
-    );
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
     return pigeonVar_replyValue! as HostAPISPConsent;
   }
 
-  Future<void> loadPrivacyManager({
-    required String pmId,
-    required HostAPIPMTab pmTab,
-    required HostAPICampaignType campaignType,
-    required HostAPIMessageType messageType,
-  }) async {
-    final pigeonVar_channelName =
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
+  Future<void> loadPrivacyManager({required String pmId, required HostAPIPMTab pmTab, required HostAPICampaignType campaignType, required HostAPIMessageType messageType, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.loadPrivacyManager$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[pmId, pmTab, campaignType, messageType],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[pmId, pmTab, campaignType, messageType]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
-      pigeonVar_replyList,
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: true,
+    )
+    ;
+  }
+
+  Future<HostAPISPConsent> customConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.customConsentGDPR$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
       pigeonVar_channelName,
-      isNullValid: true,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
     );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as HostAPISPConsent;
+  }
+
+  Future<HostAPISPConsent> deleteCustomConsentGDPR({required List<String> vendors, required List<String> categories, required List<String> legIntCategories, }) async {
+    final pigeonVar_channelName = 'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpHostApi.deleteCustomConsentGDPR$pigeonVar_messageChannelSuffix';
+    final pigeonVar_channel = BasicMessageChannel<Object?>(
+      pigeonVar_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: pigeonVar_binaryMessenger,
+    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(<Object?>[vendors, categories, legIntCategories]);
+    final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
+
+    final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
+        pigeonVar_replyList,
+        pigeonVar_channelName,
+        isNullValid: false,
+    )
+    ;
+    return pigeonVar_replyValue! as HostAPISPConsent;
   }
 }
 
@@ -884,20 +898,12 @@ abstract class SourcepointUnifiedCmpFlutterApi {
 
   void onSpFinished(HostAPISPConsent consent);
 
-  static void setUp(
-    SourcepointUnifiedCmpFlutterApi? api, {
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+  static void setUp(SourcepointUnifiedCmpFlutterApi? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
+    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIFinished$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -907,20 +913,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onUIReady$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -930,20 +932,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onError$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -955,20 +953,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onConsentReady$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -980,46 +974,37 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onAction$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
         pigeonVar_channel.setMessageHandler((Object? message) async {
           final List<Object?> args = message! as List<Object?>;
-          final HostAPIConsentAction arg_consentAction =
-              args[0]! as HostAPIConsentAction;
+          final HostAPIConsentAction arg_consentAction = args[0]! as HostAPIConsentAction;
           try {
             api.onAction(arg_consentAction);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onNoIntentActivitiesFound$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1031,20 +1016,16 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.sourcepoint_unified_cmp_ios.SourcepointUnifiedCmpFlutterApi.onSpFinished$messageChannelSuffix', pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -1056,10 +1037,8 @@ abstract class SourcepointUnifiedCmpFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
@@ -182,6 +182,20 @@ abstract class SourcepointUnifiedCmpHostApi {
     required HostAPICampaignType campaignType,
     required HostAPIMessageType messageType,
   });
+
+  @async
+  HostAPISPConsent customConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  });
+
+  @async
+  HostAPISPConsent deleteCustomConsentGDPR({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  });
 }
 
 @FlutterApi()

--- a/packages/sourcepoint_unified_cmp_ios/test/sourcepoint_unified_cmp_ios_test.dart
+++ b/packages/sourcepoint_unified_cmp_ios/test/sourcepoint_unified_cmp_ios_test.dart
@@ -41,4 +41,36 @@ void main() {
     );
     expect(consent, isNotNull);
   });
+
+  test('customConsentGDPR', () async {
+    when(
+      api.customConsentGDPR(
+        vendors: ['vendor1'],
+        categories: ['category1'],
+        legIntCategories: ['legIntCategory1'],
+      ),
+    ).thenAnswer((_) async => HostAPISPConsent());
+    final consent = await api.customConsentGDPR(
+      vendors: ['vendor1'],
+      categories: ['category1'],
+      legIntCategories: ['legIntCategory1'],
+    );
+    expect(consent, isNotNull);
+  });
+
+  test('deleteCustomConsentGDPR', () async {
+    when(
+      api.deleteCustomConsentGDPR(
+        vendors: ['vendor1'],
+        categories: ['category1'],
+        legIntCategories: ['legIntCategory1'],
+      ),
+    ).thenAnswer((_) async => HostAPISPConsent());
+    final consent = await api.deleteCustomConsentGDPR(
+      vendors: ['vendor1'],
+      categories: ['category1'],
+      legIntCategories: ['legIntCategory1'],
+    );
+    expect(consent, isNotNull);
+  });
 }

--- a/packages/sourcepoint_unified_cmp_ios/test/sourcepoint_unified_cmp_ios_test.mocks.dart
+++ b/packages/sourcepoint_unified_cmp_ios/test/sourcepoint_unified_cmp_ios_test.mocks.dart
@@ -127,4 +127,74 @@ class MockSourcepointUnifiedCmpHostApi extends _i1.Mock
             returnValueForMissingStub: _i4.Future<void>.value(),
           )
           as _i4.Future<void>);
+
+  @override
+  _i4.Future<_i2.HostAPISPConsent> customConsentGDPR({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#customConsentGDPR, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#customConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#customConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.HostAPISPConsent>);
+
+  @override
+  _i4.Future<_i2.HostAPISPConsent> deleteCustomConsentGDPR({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteCustomConsentGDPR, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#deleteCustomConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i4.Future<_i2.HostAPISPConsent>.value(
+              _FakeHostAPISPConsent_0(
+                this,
+                Invocation.method(#deleteCustomConsentGDPR, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i4.Future<_i2.HostAPISPConsent>);
 }

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/controller.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/controller.dart
@@ -29,4 +29,24 @@ abstract class AbstractSourcepointConsentController
   /// Loading the First Layer Message
   /// and returns the initial consent status
   Future<SPConsent> loadMessage();
+
+  /// Programmatically grant custom GDPR consent to the supplied [vendors],
+  /// [categories] and [legIntCategories].
+  ///
+  /// Returns the updated [SPConsent] reflecting the new consent state.
+  Future<SPConsent> customConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  });
+
+  /// Programmatically delete custom GDPR consent for the supplied [vendors],
+  /// [categories] and [legIntCategories].
+  ///
+  /// Returns the updated [SPConsent] reflecting the new consent state.
+  Future<SPConsent> deleteCustomConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  });
 }

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/interface.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/interface.dart
@@ -86,6 +86,40 @@ abstract class SourcepointUnifiedCmpPlatform extends PlatformInterface {
   ) {
     throw UnimplementedError('loadPrivacyManager() has not been implemented.');
   }
+
+  /// Programmatically grant custom GDPR consent to the supplied [vendors],
+  /// [categories] and [legIntCategories].
+  ///
+  /// Returns the updated [SPConsent] reflecting the new consent state.
+  /// The native SDKs will persist the consent locally and the registered
+  /// [ConsentChangeNotifier] and event delegate callbacks
+  /// (`onConsentReady` / `onSpFinished`) are triggered with the updated
+  /// [SPConsent].
+  Future<SPConsent> customConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) {
+    throw UnimplementedError('customConsentGdpr() has not been implemented.');
+  }
+
+  /// Programmatically delete custom GDPR consent for the supplied [vendors],
+  /// [categories] and [legIntCategories].
+  ///
+  /// Returns the updated [SPConsent] reflecting the new consent state.
+  /// The native SDKs will persist the consent locally and the registered
+  /// [ConsentChangeNotifier] and event delegate callbacks
+  /// (`onConsentReady` / `onSpFinished`) are triggered with the updated
+  /// [SPConsent].
+  Future<SPConsent> deleteCustomConsentGdpr({
+    required List<String> vendors,
+    required List<String> categories,
+    required List<String> legIntCategories,
+  }) {
+    throw UnimplementedError(
+      'deleteCustomConsentGdpr() has not been implemented.',
+    );
+  }
 }
 
 /// Represents the platform interface for handling Sourcepoint event delegates.

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/sourcepoint_unified_cmp_platform_interface_test.mocks.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/sourcepoint_unified_cmp_platform_interface_test.mocks.dart
@@ -106,4 +106,74 @@ class MockMethodChannelSourcepointUnifiedCmp extends _i1.Mock
         Invocation.method(#registerEventDelegate, [delegate]),
         returnValueForMissingStub: null,
       );
+
+  @override
+  _i5.Future<_i3.SPConsent> customConsentGdpr({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#customConsentGdpr, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#customConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#customConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.SPConsent>);
+
+  @override
+  _i5.Future<_i3.SPConsent> deleteCustomConsentGdpr({
+    required List<String>? vendors,
+    required List<String>? categories,
+    required List<String>? legIntCategories,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#deleteCustomConsentGdpr, [], {
+              #vendors: vendors,
+              #categories: categories,
+              #legIntCategories: legIntCategories,
+            }),
+            returnValue: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#deleteCustomConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+            returnValueForMissingStub: _i5.Future<_i3.SPConsent>.value(
+              _FakeSPConsent_1(
+                this,
+                Invocation.method(#deleteCustomConsentGdpr, [], {
+                  #vendors: vendors,
+                  #categories: categories,
+                  #legIntCategories: legIntCategories,
+                }),
+              ),
+            ),
+          )
+          as _i5.Future<_i3.SPConsent>);
 }


### PR DESCRIPTION
Closes #327

## Summary

Adds programmatic GDPR custom consent management to `sourcepoint_unified_cmp`, using the same native consent instance as `loadMessage` / `loadPrivacyManager`.

New public APIs (Dart):

```dart
Future<SPConsent> customConsentGdpr({
  required List<String> vendors,
  required List<String> categories,
  required List<String> legIntCategories,
});

Future<SPConsent> deleteCustomConsentGdpr({
  required List<String> vendors,
  required List<String> categories,
  required List<String> legIntCategories,
});
```

available on `SourcepointController` (and the underlying platform interface).

## Implementation notes

- **Pigeon**: new `customConsentGDPR` and `deleteCustomConsentGDPR` host messages for both `sourcepoint_unified_cmp_android` and `sourcepoint_unified_cmp_ios`. Generated Kotlin/Swift/Dart bindings updated.
- **Android**: `SourcepointUnifiedCmpPlugin` calls `spConsentLib.customConsentGDPR(...)` and `spConsentLib.deleteCustomConsentTo(...)`. Result is mapped to `HostAPISPConsent` via the existing `SPConsents.toHostAPISPConsent()` extension.
- **iOS**: `SourcepointUnifiedCmpPlugin` calls `consentManager.customConsentGDPR(...)` and `consentManager.deleteCustomConsentGDPR(...)`. A new `SPGDPRConsent.toHostAPISPConsent()` extension produces the `HostAPISPConsent` (no `SPUserData` wrapper is provided by the SDK callback for these methods).
- On success the native SDK persists consent, then the existing delegate callbacks (`onConsentReady` / `onSpFinished`) are invoked with the updated consent. That triggers the registered `ConsentChangeNotifier.updateConsent(...)` on the Dart side as a side-effect.
- If the native consent lib has not been initialized yet (i.e. `loadMessage` has not been called), the call fails with a clear `IllegalStateException` / `FlutterError`.

## Tests

- New unit tests for `customConsentGdpr` and `deleteCustomConsentGdpr` on the controller, Android Pigeon host API and iOS Pigeon host API.
- `melos run test --no-select` and `melos run analyze` pass locally.