### PR TITLE
fix(ios): guard against presenting consent VC on itself (fixes #279)

### DIFF
--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
@@ -96,7 +96,13 @@ extension SourcepointUnifiedCmpPlugin: SPDelegate {
   public func onSPUIReady(_ controller: UIViewController) {
     controller.modalPresentationStyle = .overFullScreen
     DispatchQueue.main.async {
-      getTopMostViewController()?.present(controller, animated: true)
+      guard
+        let topVC = getTopMostViewController(),
+        topVC !== controller,
+        controller.presentingViewController == nil,
+        !controller.isBeingPresented
+      else { return }
+      topVC.present(controller, animated: true)
     }
     flutterAPI?.callOnUIReady(controller: controller)
   }


### PR DESCRIPTION
## Problem

When `onSPUIReady` is called while the consent view controller is already in the presented-VC chain (e.g. two campaigns firing in quick succession, or an SDK retry), `getTopMostViewController()` walks all the way up the chain and lands on that very controller. The subsequent `present(_:animated:)` call then crashes with:

```
Fatal Exception: NSInvalidArgumentException
Application tried to present modal view controller on itself.
Presenting controller is <ConsentViewController.GenericWebMessageViewController: ...>
```

Reported in #279, reproducible across iPhone/iPad iOS 13–16.

## Fix

Guard the `present` call inside `onSPUIReady` with three conditions that must all be true before proceeding:

1. `topVC !== controller` — the topmost VC is not the controller we are about to present
2. `controller.presentingViewController == nil` — it is not already presented
3. `!controller.isBeingPresented` — presentation animation is not already in progress

If any condition fails the block is a no-op, preventing the crash.

## Change

Only `SourcepointUnifiedCmpPlugin.swift` is touched — 7 lines added, 1 removed, no logic changed outside the guard.