### PR TITLE
fix(ios): handle unsupported campaign types gracefully instead of crashing

### DIFF
--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcePointUnifiedCmpData.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcePointUnifiedCmpData.kt
@@ -85,9 +85,9 @@ fun CampaignType.toHostAPICampaignType() = when (this) {
     CampaignType.CCPA -> HostAPICampaignType.CCPA
     CampaignType.GDPR -> HostAPICampaignType.GDPR
     CampaignType.USNAT -> HostAPICampaignType.USNAT
-    CampaignType.UNKNOWN -> TODO()
-    CampaignType.GLOBALCMP -> TODO()
-    CampaignType.PREFERENCES -> TODO()
+    CampaignType.UNKNOWN -> HostAPICampaignType.UNKNOWN
+    CampaignType.GLOBALCMP -> HostAPICampaignType.GLOBALCMP
+    CampaignType.PREFERENCES -> HostAPICampaignType.PREFERENCES
 }
 
 fun ActionType.toHostAPIActionType() = when (this) {
@@ -126,6 +126,9 @@ fun HostAPICampaignType.toCampaignType() = when (this) {
     HostAPICampaignType.CCPA -> CampaignType.CCPA
     HostAPICampaignType.GDPR -> CampaignType.GDPR
     HostAPICampaignType.USNAT -> CampaignType.USNAT
+    HostAPICampaignType.UNKNOWN -> CampaignType.UNKNOWN
+    HostAPICampaignType.GLOBALCMP -> CampaignType.GLOBALCMP
+    HostAPICampaignType.PREFERENCES -> CampaignType.PREFERENCES
 }
 
 fun HostAPIMessageType.toMessageType() = when (this) {

--- a/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
+++ b/packages/sourcepoint_unified_cmp_android/android/src/main/kotlin/de/thekorn/sourcepoint/unified/cmp/SourcepointUnifiedCmp.g.kt
@@ -210,7 +210,10 @@ enum class HostAPIPMTab(val raw: Int) {
 enum class HostAPICampaignType(val raw: Int) {
   GDPR(0),
   CCPA(1),
-  USNAT(2);
+  USNAT(2),
+  UNKNOWN(3),
+  GLOBALCMP(4),
+  PREFERENCES(5);
 
   companion object {
     fun ofRaw(raw: Int): HostAPICampaignType? {

--- a/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
@@ -59,6 +59,12 @@ extension on messages.HostAPICampaignType {
         return CampaignType.ccpa;
       case messages.HostAPICampaignType.usnat:
         return CampaignType.usnat;
+      case messages.HostAPICampaignType.unknown:
+        return CampaignType.unknown;
+      case messages.HostAPICampaignType.globalcmp:
+        return CampaignType.globalcmp;
+      case messages.HostAPICampaignType.preferences:
+        return CampaignType.preferences;
     }
   }
 }
@@ -202,8 +208,14 @@ extension on CampaignType {
       case CampaignType.usnat:
         return messages.HostAPICampaignType.usnat;
       case CampaignType.unknown:
+        return messages.HostAPICampaignType.unknown;
+      case CampaignType.globalcmp:
+        return messages.HostAPICampaignType.globalcmp;
+      case CampaignType.preferences:
+        return messages.HostAPICampaignType.preferences;
+      case CampaignType.ios14:
         throw UnimplementedError(
-          'CampaignType.unknown is iOS-only and cannot be used on Android.',
+          'CampaignType.ios14 is iOS-only and cannot be used on Android.',
         );
     }
   }

--- a/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/sourcepoint_unified_cmp_android.dart
@@ -201,6 +201,10 @@ extension on CampaignType {
         return messages.HostAPICampaignType.ccpa;
       case CampaignType.usnat:
         return messages.HostAPICampaignType.usnat;
+      case CampaignType.unknown:
+        throw UnimplementedError(
+          'CampaignType.unknown is iOS-only and cannot be used on Android.',
+        );
     }
   }
 }

--- a/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_android/lib/src/messages.g.dart
@@ -113,7 +113,7 @@ int _deepHash(Object? value) {
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa, usnat }
+enum HostAPICampaignType { gdpr, ccpa, usnat, unknown, globalcmp, preferences }
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_android/pigeons/messages.dart
@@ -4,7 +4,7 @@ import 'package:pigeon/pigeon.dart';
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa, usnat }
+enum HostAPICampaignType { gdpr, ccpa, usnat, unknown, globalcmp, preferences }
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
@@ -1,145 +1,151 @@
 import ConsentViewController
 
 enum NotImplementedError: Error {
-  case notImplemented
+    case notImplemented
 }
 
 extension SPGDPRVendorGrant {
-  func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
-    HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
-  }
+    func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
+        HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
+    }
 }
 
 extension ConsentStatus {
-  func toHostAPIConsentStatus() -> HostAPIConsentStatus {
-    HostAPIConsentStatus(
-      consentedAll: consentedAll,
-      consentedToAny: consentedToAny,
-      granularStatus: nil, // NOTE: granularStatus is not public in the ios sdk
-      hasConsentData: nil, // NOTE: hasConsentData is not public in the ios sdk
-      rejectedAny: rejectedAny,
-      rejectedLI: rejectedLI,
-      legalBasisChanges: legalBasisChanges,
-      vendorListAdditions: vendorListAdditions
-    )
-  }
+    func toHostAPIConsentStatus() -> HostAPIConsentStatus {
+        HostAPIConsentStatus(
+            consentedAll: consentedAll,
+            consentedToAny: consentedToAny,
+            granularStatus: nil,  // NOTE: granularStatus is not public in the ios sdk
+            hasConsentData: nil,  // NOTE: hasConsentData is not public in the ios sdk
+            rejectedAny: rejectedAny,
+            rejectedLI: rejectedLI,
+            legalBasisChanges: legalBasisChanges,
+            vendorListAdditions: vendorListAdditions
+        )
+    }
 }
 
 extension SPConsent {
-  func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
-    if let value = self as? SPConsent<SPGDPRConsent> {
-      let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
-        .reduce(into: [:]) { result, pair in
-          let value: String? =
-            (pair.value as? String)
-              ?? (pair.value as? CustomStringConvertible)?.description
-          result[pair.key] = value
-        }
+    func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
+        if let value = self as? SPConsent<SPGDPRConsent> {
+            let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
+                .reduce(into: [:]) { result, pair in
+                    let value: String? =
+                        (pair.value as? String)
+                        ?? (pair.value as? CustomStringConvertible)?.description
+                    result[pair.key] = value
+                }
 
-      let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
-        .reduce(into: [:]) { result, pair in
-          let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
-          result[pair.key] = value.toHostAPIPurposeGrants()
-        }
+            let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
+                .reduce(into: [:]) { result, pair in
+                    let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
+                    result[pair.key] = value.toHostAPIPurposeGrants()
+                }
 
-      return HostAPIGDPRConsent(
-        uuid: value.consents!.uuid,
-        tcData: tcData,
-        grants: grants,
-        euconsent: value.consents!.euconsent,
-        acceptedCategories: value.consents!.acceptedCategories,
-        apply: value.consents!.applies,
-        consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
-      )
-    } else {
-      throw NotImplementedError.notImplemented
+            return HostAPIGDPRConsent(
+                uuid: value.consents!.uuid,
+                tcData: tcData,
+                grants: grants,
+                euconsent: value.consents!.euconsent,
+                acceptedCategories: value.consents!.acceptedCategories,
+                apply: value.consents!.applies,
+                consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
+            )
+        } else {
+            throw NotImplementedError.notImplemented
+        }
     }
-  }
 }
 
 func encodeWebConsents(webConsents: SPWebConsents) -> String? {
-  guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
-  return String(data: consentsData, encoding: .utf8)
+    guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
+    return String(data: consentsData, encoding: .utf8)
 }
 
 extension SPUserData {
-  func toHostAPISPConsent() -> HostAPISPConsent {
-    HostAPISPConsent(
-      gdpr: try? gdpr?.toHostAPIGDPRConsent(),
-      webConsents: encodeWebConsents(webConsents: webConsents)
-    )
-  }
+    func toHostAPISPConsent() -> HostAPISPConsent {
+        HostAPISPConsent(
+            gdpr: try? gdpr?.toHostAPIGDPRConsent(),
+            webConsents: encodeWebConsents(webConsents: webConsents)
+        )
+    }
 }
 
 extension HostAPICampaignsEnv {
-  func toSPCampaignEnv() -> SPCampaignEnv {
-    switch self {
-    case .stage:
-      SPCampaignEnv.Stage
-    case .publicEnv:
-      SPCampaignEnv.Public
+    func toSPCampaignEnv() -> SPCampaignEnv {
+        switch self {
+        case .stage:
+            SPCampaignEnv.Stage
+        case .publicEnv:
+            SPCampaignEnv.Public
+        }
     }
-  }
 }
 
 extension HostAPIMessageLanguage {
-  func toSPMessageLanguage() -> SPMessageLanguage {
-    switch self {
-    case .german:
-      SPMessageLanguage.German
-    case .english:
-      SPMessageLanguage.English
-    case .french:
-      SPMessageLanguage.French
-    case .italian:
-      SPMessageLanguage.Italian
-    case .spanish:
-      SPMessageLanguage.Spanish
-    case .dutch:
-      SPMessageLanguage.Dutch
+    func toSPMessageLanguage() -> SPMessageLanguage {
+        switch self {
+        case .german:
+            SPMessageLanguage.German
+        case .english:
+            SPMessageLanguage.English
+        case .french:
+            SPMessageLanguage.French
+        case .italian:
+            SPMessageLanguage.Italian
+        case .spanish:
+            SPMessageLanguage.Spanish
+        case .dutch:
+            SPMessageLanguage.Dutch
+        }
     }
-  }
 }
 
 extension HostAPIPMTab {
-  func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
-    switch self {
-    case .purposes:
-      SPPrivacyManagerTab.Purposes
-    case .defaults:
-      SPPrivacyManagerTab.Default
-    case .vendors:
-      SPPrivacyManagerTab.Vendors
-    case .features:
-      SPPrivacyManagerTab.Features
+    func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
+        switch self {
+        case .purposes:
+            SPPrivacyManagerTab.Purposes
+        case .defaults:
+            SPPrivacyManagerTab.Default
+        case .vendors:
+            SPPrivacyManagerTab.Vendors
+        case .features:
+            SPPrivacyManagerTab.Features
+        }
     }
-  }
 }
 
 extension SPAction {
-  func toHostAPIConsentAction() -> HostAPIConsentAction {
-    HostAPIConsentAction(
-      actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
-      pubData: String(describing: publisherData),
-      campaignType: campaignType.toHostAPICampaignType(),
-      customActionId: customActionId
-    )
-  }
+    func toHostAPIConsentAction() -> HostAPIConsentAction {
+        HostAPIConsentAction(
+            actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
+            pubData: String(describing: publisherData),
+            campaignType: campaignType.toHostAPICampaignType(),
+            customActionId: customActionId
+        )
+    }
 }
 
 extension SPCampaignType {
-  func toHostAPICampaignType() -> HostAPICampaignType {
-    switch self {
-    case .ccpa:
-      return HostAPICampaignType.ccpa
-    case .gdpr:
-      return HostAPICampaignType.gdpr
-    default:
-      // NOTE: .unknown, .usnat, .ios14 and other campaign types are not fully
-      // supported yet; map them to .unknown to avoid crashing
-      return HostAPICampaignType.unknown
+    func toHostAPICampaignType() -> HostAPICampaignType {
+        switch self {
+        case .ccpa:
+            return HostAPICampaignType.ccpa
+        case .gdpr:
+            return HostAPICampaignType.gdpr
+        case .usnat:
+            return HostAPICampaignType.usnat
+        case .ios14:
+            return HostAPICampaignType.ios14
+        case .globalcmp:
+            return HostAPICampaignType.globalcmp
+        case .preferences:
+            return HostAPICampaignType.preferences
+        default:
+            return HostAPICampaignType.unknown
+        }
     }
-  }
 }
 
 /// FIXME(thekorn) the anddroid and the ios sdk are actually diverging here.
@@ -147,36 +153,36 @@ extension SPCampaignType {
 ///   android is still using the old ones
 ///   once android is catching up we need to unify
 extension SPActionType {
-  func toHostAPIActionType() throws -> HostAPIActionType {
-    switch self {
-    case .SaveAndExit:
-      HostAPIActionType.saveAndExit
-    case .PMCancel:
-      HostAPIActionType.msgCancel
-    case .Custom:
-      HostAPIActionType.custom
-    case .AcceptAll:
-      HostAPIActionType.acceptAll
-    case .ShowPrivacyManager:
-      HostAPIActionType.showOptions
-    case .RejectAll:
-      HostAPIActionType.rejectAll
-    case .Dismiss:
-      HostAPIActionType.pmDismiss
-    case .RequestATTAccess:
-      throw NotImplementedError.notImplemented
-    case .IDFAAccepted:
-      throw NotImplementedError.notImplemented
-    case .IDFADenied:
-      throw NotImplementedError.notImplemented
-    case .Unknown:
-      HostAPIActionType.unknown
+    func toHostAPIActionType() throws -> HostAPIActionType {
+        switch self {
+        case .SaveAndExit:
+            HostAPIActionType.saveAndExit
+        case .PMCancel:
+            HostAPIActionType.msgCancel
+        case .Custom:
+            HostAPIActionType.custom
+        case .AcceptAll:
+            HostAPIActionType.acceptAll
+        case .ShowPrivacyManager:
+            HostAPIActionType.showOptions
+        case .RejectAll:
+            HostAPIActionType.rejectAll
+        case .Dismiss:
+            HostAPIActionType.pmDismiss
+        case .RequestATTAccess:
+            throw NotImplementedError.notImplemented
+        case .IDFAAccepted:
+            throw NotImplementedError.notImplemented
+        case .IDFADenied:
+            throw NotImplementedError.notImplemented
+        case .Unknown:
+            HostAPIActionType.unknown
+        }
     }
-  }
 }
 
 extension SPError {
-  func toHostAPISPError() -> HostAPISPError {
-    HostAPISPError(spCode: spCode, description: description)
-  }
+    func toHostAPISPError() -> HostAPISPError {
+        HostAPISPError(spCode: spCode, description: description)
+    }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
@@ -1,143 +1,145 @@
 import ConsentViewController
 
 enum NotImplementedError: Error {
-  case notImplemented
+    case notImplemented
 }
 
 extension SPGDPRVendorGrant {
-  func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
-    HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
-  }
+    func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
+        HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
+    }
 }
 
 extension ConsentStatus {
-  func toHostAPIConsentStatus() -> HostAPIConsentStatus {
-    HostAPIConsentStatus(
-      consentedAll: consentedAll,
-      consentedToAny: consentedToAny,
-      granularStatus: nil, // NOTE: granularStatus is not public in the ios sdk
-      hasConsentData: nil, // NOTE: hasConsentData is not public in the ios sdk
-      rejectedAny: rejectedAny,
-      rejectedLI: rejectedLI,
-      legalBasisChanges: legalBasisChanges,
-      vendorListAdditions: vendorListAdditions
-    )
-  }
+    func toHostAPIConsentStatus() -> HostAPIConsentStatus {
+        HostAPIConsentStatus(
+            consentedAll: consentedAll,
+            consentedToAny: consentedToAny,
+            granularStatus: nil,  // NOTE: granularStatus is not public in the ios sdk
+            hasConsentData: nil,  // NOTE: hasConsentData is not public in the ios sdk
+            rejectedAny: rejectedAny,
+            rejectedLI: rejectedLI,
+            legalBasisChanges: legalBasisChanges,
+            vendorListAdditions: vendorListAdditions
+        )
+    }
 }
 
 extension SPConsent {
-  func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
-    if let value = self as? SPConsent<SPGDPRConsent> {
-      let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
-        .reduce(into: [:]) { result, pair in
-          let value: String? = (pair.value as? String) ??
-            (pair.value as? CustomStringConvertible)?.description
-          result[pair.key] = value
-        }
+    func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
+        if let value = self as? SPConsent<SPGDPRConsent> {
+            let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
+                .reduce(into: [:]) { result, pair in
+                    let value: String? =
+                        (pair.value as? String)
+                        ?? (pair.value as? CustomStringConvertible)?.description
+                    result[pair.key] = value
+                }
 
-      let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
-        .reduce(into: [:]) { result, pair in
-          let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
-          result[pair.key] = value.toHostAPIPurposeGrants()
-        }
+            let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
+                .reduce(into: [:]) { result, pair in
+                    let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
+                    result[pair.key] = value.toHostAPIPurposeGrants()
+                }
 
-      return HostAPIGDPRConsent(
-        uuid: value.consents!.uuid,
-        tcData: tcData,
-        grants: grants,
-        euconsent: value.consents!.euconsent,
-        acceptedCategories: value.consents!.acceptedCategories,
-        apply: value.consents!.applies,
-        consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
-      )
-    } else {
-      throw NotImplementedError.notImplemented
+            return HostAPIGDPRConsent(
+                uuid: value.consents!.uuid,
+                tcData: tcData,
+                grants: grants,
+                euconsent: value.consents!.euconsent,
+                acceptedCategories: value.consents!.acceptedCategories,
+                apply: value.consents!.applies,
+                consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
+            )
+        } else {
+            throw NotImplementedError.notImplemented
+        }
     }
-  }
 }
 
 func encodeWebConsents(webConsents: SPWebConsents) -> String? {
-  guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
-  return String(data: consentsData, encoding: .utf8)
+    guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
+    return String(data: consentsData, encoding: .utf8)
 }
 
 extension SPUserData {
-  func toHostAPISPConsent() -> HostAPISPConsent {
-    HostAPISPConsent(
-      gdpr: try? gdpr?.toHostAPIGDPRConsent(),
-      webConsents: encodeWebConsents(webConsents: webConsents)
-    )
-  }
+    func toHostAPISPConsent() -> HostAPISPConsent {
+        HostAPISPConsent(
+            gdpr: try? gdpr?.toHostAPIGDPRConsent(),
+            webConsents: encodeWebConsents(webConsents: webConsents)
+        )
+    }
 }
 
 extension HostAPICampaignsEnv {
-  func toSPCampaignEnv() -> SPCampaignEnv {
-    switch self {
-    case .stage:
-      SPCampaignEnv.Stage
-    case .publicEnv:
-      SPCampaignEnv.Public
+    func toSPCampaignEnv() -> SPCampaignEnv {
+        switch self {
+        case .stage:
+            SPCampaignEnv.Stage
+        case .publicEnv:
+            SPCampaignEnv.Public
+        }
     }
-  }
 }
 
 extension HostAPIMessageLanguage {
-  func toSPMessageLanguage() -> SPMessageLanguage {
-    switch self {
-    case .german:
-      SPMessageLanguage.German
-    case .english:
-      SPMessageLanguage.English
-    case .french:
-      SPMessageLanguage.French
-    case .italian:
-      SPMessageLanguage.Italian
-    case .spanish:
-      SPMessageLanguage.Spanish
-    case .dutch:
-      SPMessageLanguage.Dutch
+    func toSPMessageLanguage() -> SPMessageLanguage {
+        switch self {
+        case .german:
+            SPMessageLanguage.German
+        case .english:
+            SPMessageLanguage.English
+        case .french:
+            SPMessageLanguage.French
+        case .italian:
+            SPMessageLanguage.Italian
+        case .spanish:
+            SPMessageLanguage.Spanish
+        case .dutch:
+            SPMessageLanguage.Dutch
+        }
     }
-  }
 }
 
 extension HostAPIPMTab {
-  func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
-    switch self {
-    case .purposes:
-      SPPrivacyManagerTab.Purposes
-    case .defaults:
-      SPPrivacyManagerTab.Default
-    case .vendors:
-      SPPrivacyManagerTab.Vendors
-    case .features:
-      SPPrivacyManagerTab.Features
+    func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
+        switch self {
+        case .purposes:
+            SPPrivacyManagerTab.Purposes
+        case .defaults:
+            SPPrivacyManagerTab.Default
+        case .vendors:
+            SPPrivacyManagerTab.Vendors
+        case .features:
+            SPPrivacyManagerTab.Features
+        }
     }
-  }
 }
 
 extension SPAction {
-  func toHostAPIConsentAction() -> HostAPIConsentAction {
-    HostAPIConsentAction(
-      actionType: try! type.toHostAPIActionType(),
-      pubData: String(describing: publisherData),
-      campaignType: try! campaignType.toHostAPICampaignType(),
-      customActionId: customActionId
-    )
-  }
+    func toHostAPIConsentAction() -> HostAPIConsentAction {
+        HostAPIConsentAction(
+            actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
+            pubData: String(describing: publisherData),
+            campaignType: campaignType.toHostAPICampaignType(),
+            customActionId: customActionId
+        )
+    }
 }
 
 extension SPCampaignType {
-  func toHostAPICampaignType() throws -> HostAPICampaignType {
-    switch self {
-    case .ccpa:
-      HostAPICampaignType.ccpa
-    case .gdpr:
-      HostAPICampaignType.gdpr
-    default:
-      // NOTE: there is no support for all other campaign types
-      throw NotImplementedError.notImplemented
+    func toHostAPICampaignType() -> HostAPICampaignType {
+        switch self {
+        case .ccpa:
+            return HostAPICampaignType.ccpa
+        case .gdpr:
+            return HostAPICampaignType.gdpr
+        default:
+            // NOTE: .unknown, .usnat, .ios14 and other campaign types are not fully
+            // supported yet; map them to .unknown to avoid crashing
+            return HostAPICampaignType.unknown
+        }
     }
-  }
 }
 
 /// FIXME(thekorn) the anddroid and the ios sdk are actually diverging here.
@@ -145,36 +147,36 @@ extension SPCampaignType {
 ///   android is still using the old ones
 ///   once android is catching up we need to unify
 extension SPActionType {
-  func toHostAPIActionType() throws -> HostAPIActionType {
-    switch self {
-    case .SaveAndExit:
-      HostAPIActionType.saveAndExit
-    case .PMCancel:
-      HostAPIActionType.msgCancel
-    case .Custom:
-      HostAPIActionType.custom
-    case .AcceptAll:
-      HostAPIActionType.acceptAll
-    case .ShowPrivacyManager:
-      HostAPIActionType.showOptions
-    case .RejectAll:
-      HostAPIActionType.rejectAll
-    case .Dismiss:
-      HostAPIActionType.pmDismiss
-    case .RequestATTAccess:
-      throw NotImplementedError.notImplemented
-    case .IDFAAccepted:
-      throw NotImplementedError.notImplemented
-    case .IDFADenied:
-      throw NotImplementedError.notImplemented
-    case .Unknown:
-      HostAPIActionType.unknown
+    func toHostAPIActionType() throws -> HostAPIActionType {
+        switch self {
+        case .SaveAndExit:
+            HostAPIActionType.saveAndExit
+        case .PMCancel:
+            HostAPIActionType.msgCancel
+        case .Custom:
+            HostAPIActionType.custom
+        case .AcceptAll:
+            HostAPIActionType.acceptAll
+        case .ShowPrivacyManager:
+            HostAPIActionType.showOptions
+        case .RejectAll:
+            HostAPIActionType.rejectAll
+        case .Dismiss:
+            HostAPIActionType.pmDismiss
+        case .RequestATTAccess:
+            throw NotImplementedError.notImplemented
+        case .IDFAAccepted:
+            throw NotImplementedError.notImplemented
+        case .IDFADenied:
+            throw NotImplementedError.notImplemented
+        case .Unknown:
+            HostAPIActionType.unknown
+        }
     }
-  }
 }
 
 extension SPError {
-  func toHostAPISPError() -> HostAPISPError {
-    HostAPISPError(spCode: spCode, description: description)
-  }
+    func toHostAPISPError() -> HostAPISPError {
+        HostAPISPError(spCode: spCode, description: description)
+    }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
@@ -1,151 +1,151 @@
 import ConsentViewController
 
 enum NotImplementedError: Error {
-    case notImplemented
+  case notImplemented
 }
 
 extension SPGDPRVendorGrant {
-    func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
-        HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
-    }
+  func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
+    HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
+  }
 }
 
 extension ConsentStatus {
-    func toHostAPIConsentStatus() -> HostAPIConsentStatus {
-        HostAPIConsentStatus(
-            consentedAll: consentedAll,
-            consentedToAny: consentedToAny,
-            granularStatus: nil,  // NOTE: granularStatus is not public in the ios sdk
-            hasConsentData: nil,  // NOTE: hasConsentData is not public in the ios sdk
-            rejectedAny: rejectedAny,
-            rejectedLI: rejectedLI,
-            legalBasisChanges: legalBasisChanges,
-            vendorListAdditions: vendorListAdditions
-        )
-    }
+  func toHostAPIConsentStatus() -> HostAPIConsentStatus {
+    HostAPIConsentStatus(
+      consentedAll: consentedAll,
+      consentedToAny: consentedToAny,
+      granularStatus: nil, // NOTE: granularStatus is not public in the ios sdk
+      hasConsentData: nil, // NOTE: hasConsentData is not public in the ios sdk
+      rejectedAny: rejectedAny,
+      rejectedLI: rejectedLI,
+      legalBasisChanges: legalBasisChanges,
+      vendorListAdditions: vendorListAdditions
+    )
+  }
 }
 
 extension SPConsent {
-    func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
-        if let value = self as? SPConsent<SPGDPRConsent> {
-            let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
-                .reduce(into: [:]) { result, pair in
-                    let value: String? =
-                        (pair.value as? String)
-                        ?? (pair.value as? CustomStringConvertible)?.description
-                    result[pair.key] = value
-                }
-
-            let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
-                .reduce(into: [:]) { result, pair in
-                    let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
-                    result[pair.key] = value.toHostAPIPurposeGrants()
-                }
-
-            return HostAPIGDPRConsent(
-                uuid: value.consents!.uuid,
-                tcData: tcData,
-                grants: grants,
-                euconsent: value.consents!.euconsent,
-                acceptedCategories: value.consents!.acceptedCategories,
-                apply: value.consents!.applies,
-                consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
-            )
-        } else {
-            throw NotImplementedError.notImplemented
+  func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
+    if let value = self as? SPConsent<SPGDPRConsent> {
+      let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
+        .reduce(into: [:]) { result, pair in
+          let value: String? =
+            (pair.value as? String)
+              ?? (pair.value as? CustomStringConvertible)?.description
+          result[pair.key] = value
         }
+
+      let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
+        .reduce(into: [:]) { result, pair in
+          let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
+          result[pair.key] = value.toHostAPIPurposeGrants()
+        }
+
+      return HostAPIGDPRConsent(
+        uuid: value.consents!.uuid,
+        tcData: tcData,
+        grants: grants,
+        euconsent: value.consents!.euconsent,
+        acceptedCategories: value.consents!.acceptedCategories,
+        apply: value.consents!.applies,
+        consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
+      )
+    } else {
+      throw NotImplementedError.notImplemented
     }
+  }
 }
 
 func encodeWebConsents(webConsents: SPWebConsents) -> String? {
-    guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
-    return String(data: consentsData, encoding: .utf8)
+  guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
+  return String(data: consentsData, encoding: .utf8)
 }
 
 extension SPUserData {
-    func toHostAPISPConsent() -> HostAPISPConsent {
-        HostAPISPConsent(
-            gdpr: try? gdpr?.toHostAPIGDPRConsent(),
-            webConsents: encodeWebConsents(webConsents: webConsents)
-        )
-    }
+  func toHostAPISPConsent() -> HostAPISPConsent {
+    HostAPISPConsent(
+      gdpr: try? gdpr?.toHostAPIGDPRConsent(),
+      webConsents: encodeWebConsents(webConsents: webConsents)
+    )
+  }
 }
 
 extension HostAPICampaignsEnv {
-    func toSPCampaignEnv() -> SPCampaignEnv {
-        switch self {
-        case .stage:
-            SPCampaignEnv.Stage
-        case .publicEnv:
-            SPCampaignEnv.Public
-        }
+  func toSPCampaignEnv() -> SPCampaignEnv {
+    switch self {
+    case .stage:
+      SPCampaignEnv.Stage
+    case .publicEnv:
+      SPCampaignEnv.Public
     }
+  }
 }
 
 extension HostAPIMessageLanguage {
-    func toSPMessageLanguage() -> SPMessageLanguage {
-        switch self {
-        case .german:
-            SPMessageLanguage.German
-        case .english:
-            SPMessageLanguage.English
-        case .french:
-            SPMessageLanguage.French
-        case .italian:
-            SPMessageLanguage.Italian
-        case .spanish:
-            SPMessageLanguage.Spanish
-        case .dutch:
-            SPMessageLanguage.Dutch
-        }
+  func toSPMessageLanguage() -> SPMessageLanguage {
+    switch self {
+    case .german:
+      SPMessageLanguage.German
+    case .english:
+      SPMessageLanguage.English
+    case .french:
+      SPMessageLanguage.French
+    case .italian:
+      SPMessageLanguage.Italian
+    case .spanish:
+      SPMessageLanguage.Spanish
+    case .dutch:
+      SPMessageLanguage.Dutch
     }
+  }
 }
 
 extension HostAPIPMTab {
-    func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
-        switch self {
-        case .purposes:
-            SPPrivacyManagerTab.Purposes
-        case .defaults:
-            SPPrivacyManagerTab.Default
-        case .vendors:
-            SPPrivacyManagerTab.Vendors
-        case .features:
-            SPPrivacyManagerTab.Features
-        }
+  func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
+    switch self {
+    case .purposes:
+      SPPrivacyManagerTab.Purposes
+    case .defaults:
+      SPPrivacyManagerTab.Default
+    case .vendors:
+      SPPrivacyManagerTab.Vendors
+    case .features:
+      SPPrivacyManagerTab.Features
     }
+  }
 }
 
 extension SPAction {
-    func toHostAPIConsentAction() -> HostAPIConsentAction {
-        HostAPIConsentAction(
-            actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
-            pubData: String(describing: publisherData),
-            campaignType: campaignType.toHostAPICampaignType(),
-            customActionId: customActionId
-        )
-    }
+  func toHostAPIConsentAction() -> HostAPIConsentAction {
+    HostAPIConsentAction(
+      actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
+      pubData: String(describing: publisherData),
+      campaignType: campaignType.toHostAPICampaignType(),
+      customActionId: customActionId
+    )
+  }
 }
 
 extension SPCampaignType {
-    func toHostAPICampaignType() -> HostAPICampaignType {
-        switch self {
-        case .ccpa:
-            return HostAPICampaignType.ccpa
-        case .gdpr:
-            return HostAPICampaignType.gdpr
-        case .usnat:
-            return HostAPICampaignType.usnat
-        case .ios14:
-            return HostAPICampaignType.ios14
-        case .globalcmp:
-            return HostAPICampaignType.globalcmp
-        case .preferences:
-            return HostAPICampaignType.preferences
-        default:
-            return HostAPICampaignType.unknown
-        }
+  func toHostAPICampaignType() -> HostAPICampaignType {
+    switch self {
+    case .ccpa:
+      return HostAPICampaignType.ccpa
+    case .gdpr:
+      return HostAPICampaignType.gdpr
+    case .usnat:
+      return HostAPICampaignType.usnat
+    case .ios14:
+      return HostAPICampaignType.ios14
+    case .globalcmp:
+      return HostAPICampaignType.globalcmp
+    case .preferences:
+      return HostAPICampaignType.preferences
+    default:
+      return HostAPICampaignType.unknown
     }
+  }
 }
 
 /// FIXME(thekorn) the anddroid and the ios sdk are actually diverging here.
@@ -153,36 +153,36 @@ extension SPCampaignType {
 ///   android is still using the old ones
 ///   once android is catching up we need to unify
 extension SPActionType {
-    func toHostAPIActionType() throws -> HostAPIActionType {
-        switch self {
-        case .SaveAndExit:
-            HostAPIActionType.saveAndExit
-        case .PMCancel:
-            HostAPIActionType.msgCancel
-        case .Custom:
-            HostAPIActionType.custom
-        case .AcceptAll:
-            HostAPIActionType.acceptAll
-        case .ShowPrivacyManager:
-            HostAPIActionType.showOptions
-        case .RejectAll:
-            HostAPIActionType.rejectAll
-        case .Dismiss:
-            HostAPIActionType.pmDismiss
-        case .RequestATTAccess:
-            throw NotImplementedError.notImplemented
-        case .IDFAAccepted:
-            throw NotImplementedError.notImplemented
-        case .IDFADenied:
-            throw NotImplementedError.notImplemented
-        case .Unknown:
-            HostAPIActionType.unknown
-        }
+  func toHostAPIActionType() throws -> HostAPIActionType {
+    switch self {
+    case .SaveAndExit:
+      HostAPIActionType.saveAndExit
+    case .PMCancel:
+      HostAPIActionType.msgCancel
+    case .Custom:
+      HostAPIActionType.custom
+    case .AcceptAll:
+      HostAPIActionType.acceptAll
+    case .ShowPrivacyManager:
+      HostAPIActionType.showOptions
+    case .RejectAll:
+      HostAPIActionType.rejectAll
+    case .Dismiss:
+      HostAPIActionType.pmDismiss
+    case .RequestATTAccess:
+      throw NotImplementedError.notImplemented
+    case .IDFAAccepted:
+      throw NotImplementedError.notImplemented
+    case .IDFADenied:
+      throw NotImplementedError.notImplemented
+    case .Unknown:
+      HostAPIActionType.unknown
     }
+  }
 }
 
 extension SPError {
-    func toHostAPISPError() -> HostAPISPError {
-        HostAPISPError(spCode: spCode, description: description)
-    }
+  func toHostAPISPError() -> HostAPISPError {
+    HostAPISPError(spCode: spCode, description: description)
+  }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpData.swift
@@ -1,145 +1,145 @@
 import ConsentViewController
 
 enum NotImplementedError: Error {
-    case notImplemented
+  case notImplemented
 }
 
 extension SPGDPRVendorGrant {
-    func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
-        HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
-    }
+  func toHostAPIPurposeGrants() -> HostAPIGDPRPurposeGrants {
+    HostAPIGDPRPurposeGrants(granted: granted, purposeGrants: purposeGrants)
+  }
 }
 
 extension ConsentStatus {
-    func toHostAPIConsentStatus() -> HostAPIConsentStatus {
-        HostAPIConsentStatus(
-            consentedAll: consentedAll,
-            consentedToAny: consentedToAny,
-            granularStatus: nil,  // NOTE: granularStatus is not public in the ios sdk
-            hasConsentData: nil,  // NOTE: hasConsentData is not public in the ios sdk
-            rejectedAny: rejectedAny,
-            rejectedLI: rejectedLI,
-            legalBasisChanges: legalBasisChanges,
-            vendorListAdditions: vendorListAdditions
-        )
-    }
+  func toHostAPIConsentStatus() -> HostAPIConsentStatus {
+    HostAPIConsentStatus(
+      consentedAll: consentedAll,
+      consentedToAny: consentedToAny,
+      granularStatus: nil, // NOTE: granularStatus is not public in the ios sdk
+      hasConsentData: nil, // NOTE: hasConsentData is not public in the ios sdk
+      rejectedAny: rejectedAny,
+      rejectedLI: rejectedLI,
+      legalBasisChanges: legalBasisChanges,
+      vendorListAdditions: vendorListAdditions
+    )
+  }
 }
 
 extension SPConsent {
-    func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
-        if let value = self as? SPConsent<SPGDPRConsent> {
-            let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
-                .reduce(into: [:]) { result, pair in
-                    let value: String? =
-                        (pair.value as? String)
-                        ?? (pair.value as? CustomStringConvertible)?.description
-                    result[pair.key] = value
-                }
-
-            let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
-                .reduce(into: [:]) { result, pair in
-                    let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
-                    result[pair.key] = value.toHostAPIPurposeGrants()
-                }
-
-            return HostAPIGDPRConsent(
-                uuid: value.consents!.uuid,
-                tcData: tcData,
-                grants: grants,
-                euconsent: value.consents!.euconsent,
-                acceptedCategories: value.consents!.acceptedCategories,
-                apply: value.consents!.applies,
-                consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
-            )
-        } else {
-            throw NotImplementedError.notImplemented
+  func toHostAPIGDPRConsent() throws -> HostAPIGDPRConsent {
+    if let value = self as? SPConsent<SPGDPRConsent> {
+      let tcData: [String?: String?]? = value.consents!.tcfData?.dictionaryValue?
+        .reduce(into: [:]) { result, pair in
+          let value: String? =
+            (pair.value as? String)
+              ?? (pair.value as? CustomStringConvertible)?.description
+          result[pair.key] = value
         }
+
+      let grants: [String?: HostAPIGDPRPurposeGrants?]? = value.consents?.vendorGrants
+        .reduce(into: [:]) { result, pair in
+          let value: SPGDPRVendorGrant = pair.value as SPGDPRVendorGrant
+          result[pair.key] = value.toHostAPIPurposeGrants()
+        }
+
+      return HostAPIGDPRConsent(
+        uuid: value.consents!.uuid,
+        tcData: tcData,
+        grants: grants,
+        euconsent: value.consents!.euconsent,
+        acceptedCategories: value.consents!.acceptedCategories,
+        apply: value.consents!.applies,
+        consentStatus: value.consents!.consentStatus.toHostAPIConsentStatus()
+      )
+    } else {
+      throw NotImplementedError.notImplemented
     }
+  }
 }
 
 func encodeWebConsents(webConsents: SPWebConsents) -> String? {
-    guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
-    return String(data: consentsData, encoding: .utf8)
+  guard let consentsData = try? JSONEncoder().encode(webConsents) else { return nil }
+  return String(data: consentsData, encoding: .utf8)
 }
 
 extension SPUserData {
-    func toHostAPISPConsent() -> HostAPISPConsent {
-        HostAPISPConsent(
-            gdpr: try? gdpr?.toHostAPIGDPRConsent(),
-            webConsents: encodeWebConsents(webConsents: webConsents)
-        )
-    }
+  func toHostAPISPConsent() -> HostAPISPConsent {
+    HostAPISPConsent(
+      gdpr: try? gdpr?.toHostAPIGDPRConsent(),
+      webConsents: encodeWebConsents(webConsents: webConsents)
+    )
+  }
 }
 
 extension HostAPICampaignsEnv {
-    func toSPCampaignEnv() -> SPCampaignEnv {
-        switch self {
-        case .stage:
-            SPCampaignEnv.Stage
-        case .publicEnv:
-            SPCampaignEnv.Public
-        }
+  func toSPCampaignEnv() -> SPCampaignEnv {
+    switch self {
+    case .stage:
+      SPCampaignEnv.Stage
+    case .publicEnv:
+      SPCampaignEnv.Public
     }
+  }
 }
 
 extension HostAPIMessageLanguage {
-    func toSPMessageLanguage() -> SPMessageLanguage {
-        switch self {
-        case .german:
-            SPMessageLanguage.German
-        case .english:
-            SPMessageLanguage.English
-        case .french:
-            SPMessageLanguage.French
-        case .italian:
-            SPMessageLanguage.Italian
-        case .spanish:
-            SPMessageLanguage.Spanish
-        case .dutch:
-            SPMessageLanguage.Dutch
-        }
+  func toSPMessageLanguage() -> SPMessageLanguage {
+    switch self {
+    case .german:
+      SPMessageLanguage.German
+    case .english:
+      SPMessageLanguage.English
+    case .french:
+      SPMessageLanguage.French
+    case .italian:
+      SPMessageLanguage.Italian
+    case .spanish:
+      SPMessageLanguage.Spanish
+    case .dutch:
+      SPMessageLanguage.Dutch
     }
+  }
 }
 
 extension HostAPIPMTab {
-    func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
-        switch self {
-        case .purposes:
-            SPPrivacyManagerTab.Purposes
-        case .defaults:
-            SPPrivacyManagerTab.Default
-        case .vendors:
-            SPPrivacyManagerTab.Vendors
-        case .features:
-            SPPrivacyManagerTab.Features
-        }
+  func toSPPrivacyManagerTab() -> SPPrivacyManagerTab {
+    switch self {
+    case .purposes:
+      SPPrivacyManagerTab.Purposes
+    case .defaults:
+      SPPrivacyManagerTab.Default
+    case .vendors:
+      SPPrivacyManagerTab.Vendors
+    case .features:
+      SPPrivacyManagerTab.Features
     }
+  }
 }
 
 extension SPAction {
-    func toHostAPIConsentAction() -> HostAPIConsentAction {
-        HostAPIConsentAction(
-            actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
-            pubData: String(describing: publisherData),
-            campaignType: campaignType.toHostAPICampaignType(),
-            customActionId: customActionId
-        )
-    }
+  func toHostAPIConsentAction() -> HostAPIConsentAction {
+    HostAPIConsentAction(
+      actionType: (try? type.toHostAPIActionType()) ?? HostAPIActionType.unknown,
+      pubData: String(describing: publisherData),
+      campaignType: campaignType.toHostAPICampaignType(),
+      customActionId: customActionId
+    )
+  }
 }
 
 extension SPCampaignType {
-    func toHostAPICampaignType() -> HostAPICampaignType {
-        switch self {
-        case .ccpa:
-            return HostAPICampaignType.ccpa
-        case .gdpr:
-            return HostAPICampaignType.gdpr
-        default:
-            // NOTE: .unknown, .usnat, .ios14 and other campaign types are not fully
-            // supported yet; map them to .unknown to avoid crashing
-            return HostAPICampaignType.unknown
-        }
+  func toHostAPICampaignType() -> HostAPICampaignType {
+    switch self {
+    case .ccpa:
+      return HostAPICampaignType.ccpa
+    case .gdpr:
+      return HostAPICampaignType.gdpr
+    default:
+      // NOTE: .unknown, .usnat, .ios14 and other campaign types are not fully
+      // supported yet; map them to .unknown to avoid crashing
+      return HostAPICampaignType.unknown
     }
+  }
 }
 
 /// FIXME(thekorn) the anddroid and the ios sdk are actually diverging here.
@@ -147,36 +147,36 @@ extension SPCampaignType {
 ///   android is still using the old ones
 ///   once android is catching up we need to unify
 extension SPActionType {
-    func toHostAPIActionType() throws -> HostAPIActionType {
-        switch self {
-        case .SaveAndExit:
-            HostAPIActionType.saveAndExit
-        case .PMCancel:
-            HostAPIActionType.msgCancel
-        case .Custom:
-            HostAPIActionType.custom
-        case .AcceptAll:
-            HostAPIActionType.acceptAll
-        case .ShowPrivacyManager:
-            HostAPIActionType.showOptions
-        case .RejectAll:
-            HostAPIActionType.rejectAll
-        case .Dismiss:
-            HostAPIActionType.pmDismiss
-        case .RequestATTAccess:
-            throw NotImplementedError.notImplemented
-        case .IDFAAccepted:
-            throw NotImplementedError.notImplemented
-        case .IDFADenied:
-            throw NotImplementedError.notImplemented
-        case .Unknown:
-            HostAPIActionType.unknown
-        }
+  func toHostAPIActionType() throws -> HostAPIActionType {
+    switch self {
+    case .SaveAndExit:
+      HostAPIActionType.saveAndExit
+    case .PMCancel:
+      HostAPIActionType.msgCancel
+    case .Custom:
+      HostAPIActionType.custom
+    case .AcceptAll:
+      HostAPIActionType.acceptAll
+    case .ShowPrivacyManager:
+      HostAPIActionType.showOptions
+    case .RejectAll:
+      HostAPIActionType.rejectAll
+    case .Dismiss:
+      HostAPIActionType.pmDismiss
+    case .RequestATTAccess:
+      throw NotImplementedError.notImplemented
+    case .IDFAAccepted:
+      throw NotImplementedError.notImplemented
+    case .IDFADenied:
+      throw NotImplementedError.notImplemented
+    case .Unknown:
+      HostAPIActionType.unknown
     }
+  }
 }
 
 extension SPError {
-    func toHostAPISPError() -> HostAPISPError {
-        HostAPISPError(spCode: spCode, description: description)
-    }
+  func toHostAPISPError() -> HostAPISPError {
+    HostAPISPError(spCode: spCode, description: description)
+  }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
@@ -6,132 +6,146 @@ import UIKit
 extension FlutterError: Error {}
 
 public class SourcepointUnifiedCmpPlugin: UIViewController, FlutterPlugin,
-  SourcepointUnifiedCmpHostApi {
-  public static var instance: SourcepointUnifiedCmpPlugin?
-  private var consentManager: SPSDK!
-  private var isInitialized: Completer<SPUserData> = .init()
-  private var flutterAPI: SourcepointFlutterApi?
+    SourcepointUnifiedCmpHostApi
+{
+    public static var instance: SourcepointUnifiedCmpPlugin?
+    private var consentManager: SPSDK!
+    private var isInitialized: Completer<SPUserData> = .init()
+    private var flutterAPI: SourcepointFlutterApi?
 
-  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
-                   messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
-                   messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
-                   completion: @escaping (Result<HostAPISPConsent, Error>) -> Void) {
-    consentManager = SPConsentManager(
-      accountId: Int(accountId),
-      propertyId: Int(propertyId),
-      propertyName: try! SPPropertyName(propertyName),
-      campaigns: SPCampaigns(
-        gdpr: runGDPRCampaign ? SPCampaign() : nil,
-        ccpa: runCCPACampaign ? SPCampaign() : nil,
-        environment: campaignsEnv.toSPCampaignEnv()
-      ),
-      delegate: self
-    )
-    consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
-    consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
-    consentManager.loadMessage()
-    isInitialized.setCompletionHandler { [completion] result in
-      completion(.success(result.toHostAPISPConsent()))
+    func loadMessage(
+        accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
+        messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
+        messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
+        completion: @escaping (Result<HostAPISPConsent, Error>) -> Void
+    ) {
+        consentManager = SPConsentManager(
+            accountId: Int(accountId),
+            propertyId: Int(propertyId),
+            propertyName: try! SPPropertyName(propertyName),
+            campaigns: SPCampaigns(
+                gdpr: runGDPRCampaign ? SPCampaign() : nil,
+                ccpa: runCCPACampaign ? SPCampaign() : nil,
+                environment: campaignsEnv.toSPCampaignEnv()
+            ),
+            delegate: self
+        )
+        consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
+        consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
+        consentManager.loadMessage()
+        isInitialized.setCompletionHandler { [completion] result in
+            completion(.success(result.toHostAPISPConsent()))
+        }
     }
-  }
 
-  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
-                          messageType _: HostAPIMessageType,
-                          completion _: @escaping (Result<Void, Error>) -> Void) {
-    switch campaignType {
-    case HostAPICampaignType.gdpr:
-      consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-    case HostAPICampaignType.ccpa:
-      consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-    case HostAPICampaignType.unknown:
-      break
+    func loadPrivacyManager(
+        pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
+        messageType _: HostAPIMessageType,
+        completion _: @escaping (Result<Void, Error>) -> Void
+    ) {
+        switch campaignType {
+        case HostAPICampaignType.gdpr:
+            consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+        case HostAPICampaignType.ccpa:
+            consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+        case HostAPICampaignType.usnat:
+            consentManager.loadUSNatPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+        case HostAPICampaignType.globalcmp:
+            consentManager.loadGlobalCmpPrivacyManager(
+                withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+        case HostAPICampaignType.preferences:
+            consentManager.loadPreferenceCenter(withId: pmId)
+        case HostAPICampaignType.ios14:
+            break
+        case HostAPICampaignType.unknown:
+            break
+        }
     }
-  }
 
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    instance = SourcepointUnifiedCmpPlugin()
-    instance?.onRegister(registrar)
-  }
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        instance = SourcepointUnifiedCmpPlugin()
+        instance?.onRegister(registrar)
+    }
 
-  public func onRegister(_ registrar: FlutterPluginRegistrar) {
-    let messenger: FlutterBinaryMessenger = registrar.messenger()
-    SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
-    flutterAPI = SourcepointFlutterApi(messenger: messenger)
-  }
+    public func onRegister(_ registrar: FlutterPluginRegistrar) {
+        let messenger: FlutterBinaryMessenger = registrar.messenger()
+        SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
+        flutterAPI = SourcepointFlutterApi(messenger: messenger)
+    }
 }
 
 private class SourcepointFlutterApi {
-  private var flutterAPI: SourcepointUnifiedCmpFlutterApi
+    private var flutterAPI: SourcepointUnifiedCmpFlutterApi
 
-  init(messenger: FlutterBinaryMessenger) {
-    flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
-  }
+    init(messenger: FlutterBinaryMessenger) {
+        flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
+    }
 
-  func callOnConsentReady(userData: SPUserData) {
-    flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
-  }
+    func callOnConsentReady(userData: SPUserData) {
+        flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
+    }
 
-  func callOnUIReady(controller: UIViewController) {
-    flutterAPI.onUIReady { _ in }
-  }
+    func callOnUIReady(controller: UIViewController) {
+        flutterAPI.onUIReady { _ in }
+    }
 
-  func callOnAction(controller: UIViewController, action: SPAction) {
-    flutterAPI.onAction(
-      consentAction: action.toHostAPIConsentAction()
-    ) { _ in }
-  }
+    func callOnAction(controller: UIViewController, action: SPAction) {
+        flutterAPI.onAction(
+            consentAction: action.toHostAPIConsentAction()
+        ) { _ in }
+    }
 
-  func callOnUIFinished(controller: UIViewController) {
-    flutterAPI.onUIFinished { _ in }
-  }
+    func callOnUIFinished(controller: UIViewController) {
+        flutterAPI.onUIFinished { _ in }
+    }
 
-  func callOnSpFinished(userData: SPUserData) {
-    flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
-  }
+    func callOnSpFinished(userData: SPUserData) {
+        flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
+    }
 
-  func callOnError(error: SPError) {
-    flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
-  }
+    func callOnError(error: SPError) {
+        flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
+    }
 }
 
 extension SourcepointUnifiedCmpPlugin: SPDelegate {
-  public func onSPUIReady(_ controller: UIViewController) {
-    controller.modalPresentationStyle = .overFullScreen
-    DispatchQueue.main.async {
-      guard
-        let topVC = getTopMostViewController(),
-        topVC !== controller,
-        controller.presentingViewController == nil,
-        !controller.isBeingPresented
-      else { return }
-      topVC.present(controller, animated: true)
+    public func onSPUIReady(_ controller: UIViewController) {
+        controller.modalPresentationStyle = .overFullScreen
+        DispatchQueue.main.async {
+            guard
+                let topVC = getTopMostViewController(),
+                topVC !== controller,
+                controller.presentingViewController == nil,
+                !controller.isBeingPresented
+            else { return }
+            topVC.present(controller, animated: true)
+        }
+        flutterAPI?.callOnUIReady(controller: controller)
     }
-    flutterAPI?.callOnUIReady(controller: controller)
-  }
 
-  public func onAction(_ action: SPAction, from controller: UIViewController) {
-    flutterAPI?.callOnAction(controller: controller, action: action)
-  }
+    public func onAction(_ action: SPAction, from controller: UIViewController) {
+        flutterAPI?.callOnAction(controller: controller, action: action)
+    }
 
-  public func onSPUIFinished(_ controller: UIViewController) {
-    getTopMostViewController()?.dismiss(animated: true)
-    flutterAPI?.callOnUIFinished(controller: controller)
-  }
+    public func onSPUIFinished(_ controller: UIViewController) {
+        getTopMostViewController()?.dismiss(animated: true)
+        flutterAPI?.callOnUIFinished(controller: controller)
+    }
 
-  public func onSPFinished(userData: SPUserData) {
-    flutterAPI?.callOnSpFinished(userData: userData)
-  }
+    public func onSPFinished(userData: SPUserData) {
+        flutterAPI?.callOnSpFinished(userData: userData)
+    }
 
-  public func onConsentReady(userData: SPUserData) {
-    isInitialized.complete(result: userData)
-    flutterAPI?.callOnConsentReady(userData: userData)
-  }
+    public func onConsentReady(userData: SPUserData) {
+        isInitialized.complete(result: userData)
+        flutterAPI?.callOnConsentReady(userData: userData)
+    }
 
-  public func onError(error: SPError) {
-    flutterAPI?.callOnError(error: error)
-  }
+    public func onError(error: SPError) {
+        flutterAPI?.callOnError(error: error)
+    }
 
-  public func onSPNativeMessageReady(_: SPNativeMessage) {
-    logger.debug(message: "onSPNativeMessageReady")
-  }
+    public func onSPNativeMessageReady(_: SPNativeMessage) {
+        logger.debug(message: "onSPNativeMessageReady")
+    }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
@@ -6,130 +6,137 @@ import UIKit
 extension FlutterError: Error {}
 
 public class SourcepointUnifiedCmpPlugin: UIViewController, FlutterPlugin,
-  SourcepointUnifiedCmpHostApi {
-  public static var instance: SourcepointUnifiedCmpPlugin?
-  private var consentManager: SPSDK!
-  private var isInitialized: Completer<SPUserData> = .init()
-  private var flutterAPI: SourcepointFlutterApi?
+    SourcepointUnifiedCmpHostApi
+{
+    public static var instance: SourcepointUnifiedCmpPlugin?
+    private var consentManager: SPSDK!
+    private var isInitialized: Completer<SPUserData> = .init()
+    private var flutterAPI: SourcepointFlutterApi?
 
-  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
-                   messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
-                   messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
-                   completion: @escaping (Result<HostAPISPConsent, Error>) -> Void) {
-    consentManager = SPConsentManager(
-      accountId: Int(accountId),
-      propertyId: Int(propertyId),
-      propertyName: try! SPPropertyName(propertyName),
-      campaigns: SPCampaigns(
-        gdpr: runGDPRCampaign ? SPCampaign() : nil,
-        ccpa: runCCPACampaign ? SPCampaign() : nil,
-        environment: campaignsEnv.toSPCampaignEnv()
-      ),
-      delegate: self
-    )
-    consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
-    consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
-    consentManager.loadMessage()
-    isInitialized.setCompletionHandler { [completion] result in
-      completion(.success(result.toHostAPISPConsent()))
+    func loadMessage(
+        accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
+        messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
+        messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
+        completion: @escaping (Result<HostAPISPConsent, Error>) -> Void
+    ) {
+        consentManager = SPConsentManager(
+            accountId: Int(accountId),
+            propertyId: Int(propertyId),
+            propertyName: try! SPPropertyName(propertyName),
+            campaigns: SPCampaigns(
+                gdpr: runGDPRCampaign ? SPCampaign() : nil,
+                ccpa: runCCPACampaign ? SPCampaign() : nil,
+                environment: campaignsEnv.toSPCampaignEnv()
+            ),
+            delegate: self
+        )
+        consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
+        consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
+        consentManager.loadMessage()
+        isInitialized.setCompletionHandler { [completion] result in
+            completion(.success(result.toHostAPISPConsent()))
+        }
     }
-  }
 
-  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
-                          messageType _: HostAPIMessageType,
-                          completion _: @escaping (Result<Void, Error>) -> Void) {
-    switch campaignType {
-    case HostAPICampaignType.gdpr:
-      consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-    case HostAPICampaignType.ccpa:
-      consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    func loadPrivacyManager(
+        pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
+        messageType _: HostAPIMessageType,
+        completion _: @escaping (Result<Void, Error>) -> Void
+    ) {
+        switch campaignType {
+        case HostAPICampaignType.gdpr:
+            consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+        case HostAPICampaignType.ccpa:
+            consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+        case HostAPICampaignType.unknown:
+            break
+        }
     }
-  }
 
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    instance = SourcepointUnifiedCmpPlugin()
-    instance?.onRegister(registrar)
-  }
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        instance = SourcepointUnifiedCmpPlugin()
+        instance?.onRegister(registrar)
+    }
 
-  public func onRegister(_ registrar: FlutterPluginRegistrar) {
-    let messenger: FlutterBinaryMessenger = registrar.messenger()
-    SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
-    flutterAPI = SourcepointFlutterApi(messenger: messenger)
-  }
+    public func onRegister(_ registrar: FlutterPluginRegistrar) {
+        let messenger: FlutterBinaryMessenger = registrar.messenger()
+        SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
+        flutterAPI = SourcepointFlutterApi(messenger: messenger)
+    }
 }
 
 private class SourcepointFlutterApi {
-  private var flutterAPI: SourcepointUnifiedCmpFlutterApi
+    private var flutterAPI: SourcepointUnifiedCmpFlutterApi
 
-  init(messenger: FlutterBinaryMessenger) {
-    flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
-  }
+    init(messenger: FlutterBinaryMessenger) {
+        flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
+    }
 
-  func callOnConsentReady(userData: SPUserData) {
-    flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
-  }
+    func callOnConsentReady(userData: SPUserData) {
+        flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
+    }
 
-  func callOnUIReady(controller: UIViewController) {
-    flutterAPI.onUIReady { _ in }
-  }
+    func callOnUIReady(controller: UIViewController) {
+        flutterAPI.onUIReady { _ in }
+    }
 
-  func callOnAction(controller: UIViewController, action: SPAction) {
-    flutterAPI.onAction(
-      consentAction: action.toHostAPIConsentAction()
-    ) { _ in }
-  }
+    func callOnAction(controller: UIViewController, action: SPAction) {
+        flutterAPI.onAction(
+            consentAction: action.toHostAPIConsentAction()
+        ) { _ in }
+    }
 
-  func callOnUIFinished(controller: UIViewController) {
-    flutterAPI.onUIFinished { _ in }
-  }
+    func callOnUIFinished(controller: UIViewController) {
+        flutterAPI.onUIFinished { _ in }
+    }
 
-  func callOnSpFinished(userData: SPUserData) {
-    flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
-  }
+    func callOnSpFinished(userData: SPUserData) {
+        flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
+    }
 
-  func callOnError(error: SPError) {
-    flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
-  }
+    func callOnError(error: SPError) {
+        flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
+    }
 }
 
 extension SourcepointUnifiedCmpPlugin: SPDelegate {
-  public func onSPUIReady(_ controller: UIViewController) {
-    controller.modalPresentationStyle = .overFullScreen
-    DispatchQueue.main.async {
-      guard
-        let topVC = getTopMostViewController(),
-        topVC !== controller,
-        controller.presentingViewController == nil,
-        !controller.isBeingPresented
-      else { return }
-      topVC.present(controller, animated: true)
+    public func onSPUIReady(_ controller: UIViewController) {
+        controller.modalPresentationStyle = .overFullScreen
+        DispatchQueue.main.async {
+            guard
+                let topVC = getTopMostViewController(),
+                topVC !== controller,
+                controller.presentingViewController == nil,
+                !controller.isBeingPresented
+            else { return }
+            topVC.present(controller, animated: true)
+        }
+        flutterAPI?.callOnUIReady(controller: controller)
     }
-    flutterAPI?.callOnUIReady(controller: controller)
-  }
 
-  public func onAction(_ action: SPAction, from controller: UIViewController) {
-    flutterAPI?.callOnAction(controller: controller, action: action)
-  }
+    public func onAction(_ action: SPAction, from controller: UIViewController) {
+        flutterAPI?.callOnAction(controller: controller, action: action)
+    }
 
-  public func onSPUIFinished(_ controller: UIViewController) {
-    getTopMostViewController()?.dismiss(animated: true)
-    flutterAPI?.callOnUIFinished(controller: controller)
-  }
+    public func onSPUIFinished(_ controller: UIViewController) {
+        getTopMostViewController()?.dismiss(animated: true)
+        flutterAPI?.callOnUIFinished(controller: controller)
+    }
 
-  public func onSPFinished(userData: SPUserData) {
-    flutterAPI?.callOnSpFinished(userData: userData)
-  }
+    public func onSPFinished(userData: SPUserData) {
+        flutterAPI?.callOnSpFinished(userData: userData)
+    }
 
-  public func onConsentReady(userData: SPUserData) {
-    isInitialized.complete(result: userData)
-    flutterAPI?.callOnConsentReady(userData: userData)
-  }
+    public func onConsentReady(userData: SPUserData) {
+        isInitialized.complete(result: userData)
+        flutterAPI?.callOnConsentReady(userData: userData)
+    }
 
-  public func onError(error: SPError) {
-    flutterAPI?.callOnError(error: error)
-  }
+    public func onError(error: SPError) {
+        flutterAPI?.callOnError(error: error)
+    }
 
-  public func onSPNativeMessageReady(_: SPNativeMessage) {
-    logger.debug(message: "onSPNativeMessageReady")
-  }
+    public func onSPNativeMessageReady(_: SPNativeMessage) {
+        logger.debug(message: "onSPNativeMessageReady")
+    }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
@@ -6,137 +6,132 @@ import UIKit
 extension FlutterError: Error {}
 
 public class SourcepointUnifiedCmpPlugin: UIViewController, FlutterPlugin,
-    SourcepointUnifiedCmpHostApi
-{
-    public static var instance: SourcepointUnifiedCmpPlugin?
-    private var consentManager: SPSDK!
-    private var isInitialized: Completer<SPUserData> = .init()
-    private var flutterAPI: SourcepointFlutterApi?
+  SourcepointUnifiedCmpHostApi {
+  public static var instance: SourcepointUnifiedCmpPlugin?
+  private var consentManager: SPSDK!
+  private var isInitialized: Completer<SPUserData> = .init()
+  private var flutterAPI: SourcepointFlutterApi?
 
-    func loadMessage(
-        accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
-        messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
-        messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
-        completion: @escaping (Result<HostAPISPConsent, Error>) -> Void
-    ) {
-        consentManager = SPConsentManager(
-            accountId: Int(accountId),
-            propertyId: Int(propertyId),
-            propertyName: try! SPPropertyName(propertyName),
-            campaigns: SPCampaigns(
-                gdpr: runGDPRCampaign ? SPCampaign() : nil,
-                ccpa: runCCPACampaign ? SPCampaign() : nil,
-                environment: campaignsEnv.toSPCampaignEnv()
-            ),
-            delegate: self
-        )
-        consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
-        consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
-        consentManager.loadMessage()
-        isInitialized.setCompletionHandler { [completion] result in
-            completion(.success(result.toHostAPISPConsent()))
-        }
+  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
+                   messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
+                   messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
+                   completion: @escaping (Result<HostAPISPConsent, Error>) -> Void) {
+    consentManager = SPConsentManager(
+      accountId: Int(accountId),
+      propertyId: Int(propertyId),
+      propertyName: try! SPPropertyName(propertyName),
+      campaigns: SPCampaigns(
+        gdpr: runGDPRCampaign ? SPCampaign() : nil,
+        ccpa: runCCPACampaign ? SPCampaign() : nil,
+        environment: campaignsEnv.toSPCampaignEnv()
+      ),
+      delegate: self
+    )
+    consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
+    consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
+    consentManager.loadMessage()
+    isInitialized.setCompletionHandler { [completion] result in
+      completion(.success(result.toHostAPISPConsent()))
     }
+  }
 
-    func loadPrivacyManager(
-        pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
-        messageType _: HostAPIMessageType,
-        completion _: @escaping (Result<Void, Error>) -> Void
-    ) {
-        switch campaignType {
-        case HostAPICampaignType.gdpr:
-            consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-        case HostAPICampaignType.ccpa:
-            consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-        case HostAPICampaignType.unknown:
-            break
-        }
+  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
+                          messageType _: HostAPIMessageType,
+                          completion _: @escaping (Result<Void, Error>) -> Void) {
+    switch campaignType {
+    case HostAPICampaignType.gdpr:
+      consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    case HostAPICampaignType.ccpa:
+      consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    case HostAPICampaignType.unknown:
+      break
     }
+  }
 
-    public static func register(with registrar: FlutterPluginRegistrar) {
-        instance = SourcepointUnifiedCmpPlugin()
-        instance?.onRegister(registrar)
-    }
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    instance = SourcepointUnifiedCmpPlugin()
+    instance?.onRegister(registrar)
+  }
 
-    public func onRegister(_ registrar: FlutterPluginRegistrar) {
-        let messenger: FlutterBinaryMessenger = registrar.messenger()
-        SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
-        flutterAPI = SourcepointFlutterApi(messenger: messenger)
-    }
+  public func onRegister(_ registrar: FlutterPluginRegistrar) {
+    let messenger: FlutterBinaryMessenger = registrar.messenger()
+    SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
+    flutterAPI = SourcepointFlutterApi(messenger: messenger)
+  }
 }
 
 private class SourcepointFlutterApi {
-    private var flutterAPI: SourcepointUnifiedCmpFlutterApi
+  private var flutterAPI: SourcepointUnifiedCmpFlutterApi
 
-    init(messenger: FlutterBinaryMessenger) {
-        flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
-    }
+  init(messenger: FlutterBinaryMessenger) {
+    flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
+  }
 
-    func callOnConsentReady(userData: SPUserData) {
-        flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
-    }
+  func callOnConsentReady(userData: SPUserData) {
+    flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
+  }
 
-    func callOnUIReady(controller: UIViewController) {
-        flutterAPI.onUIReady { _ in }
-    }
+  func callOnUIReady(controller: UIViewController) {
+    flutterAPI.onUIReady { _ in }
+  }
 
-    func callOnAction(controller: UIViewController, action: SPAction) {
-        flutterAPI.onAction(
-            consentAction: action.toHostAPIConsentAction()
-        ) { _ in }
-    }
+  func callOnAction(controller: UIViewController, action: SPAction) {
+    flutterAPI.onAction(
+      consentAction: action.toHostAPIConsentAction()
+    ) { _ in }
+  }
 
-    func callOnUIFinished(controller: UIViewController) {
-        flutterAPI.onUIFinished { _ in }
-    }
+  func callOnUIFinished(controller: UIViewController) {
+    flutterAPI.onUIFinished { _ in }
+  }
 
-    func callOnSpFinished(userData: SPUserData) {
-        flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
-    }
+  func callOnSpFinished(userData: SPUserData) {
+    flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
+  }
 
-    func callOnError(error: SPError) {
-        flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
-    }
+  func callOnError(error: SPError) {
+    flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
+  }
 }
 
 extension SourcepointUnifiedCmpPlugin: SPDelegate {
-    public func onSPUIReady(_ controller: UIViewController) {
-        controller.modalPresentationStyle = .overFullScreen
-        DispatchQueue.main.async {
-            guard
-                let topVC = getTopMostViewController(),
-                topVC !== controller,
-                controller.presentingViewController == nil,
-                !controller.isBeingPresented
-            else { return }
-            topVC.present(controller, animated: true)
-        }
-        flutterAPI?.callOnUIReady(controller: controller)
+  public func onSPUIReady(_ controller: UIViewController) {
+    controller.modalPresentationStyle = .overFullScreen
+    DispatchQueue.main.async {
+      guard
+        let topVC = getTopMostViewController(),
+        topVC !== controller,
+        controller.presentingViewController == nil,
+        !controller.isBeingPresented
+      else { return }
+      topVC.present(controller, animated: true)
     }
+    flutterAPI?.callOnUIReady(controller: controller)
+  }
 
-    public func onAction(_ action: SPAction, from controller: UIViewController) {
-        flutterAPI?.callOnAction(controller: controller, action: action)
-    }
+  public func onAction(_ action: SPAction, from controller: UIViewController) {
+    flutterAPI?.callOnAction(controller: controller, action: action)
+  }
 
-    public func onSPUIFinished(_ controller: UIViewController) {
-        getTopMostViewController()?.dismiss(animated: true)
-        flutterAPI?.callOnUIFinished(controller: controller)
-    }
+  public func onSPUIFinished(_ controller: UIViewController) {
+    getTopMostViewController()?.dismiss(animated: true)
+    flutterAPI?.callOnUIFinished(controller: controller)
+  }
 
-    public func onSPFinished(userData: SPUserData) {
-        flutterAPI?.callOnSpFinished(userData: userData)
-    }
+  public func onSPFinished(userData: SPUserData) {
+    flutterAPI?.callOnSpFinished(userData: userData)
+  }
 
-    public func onConsentReady(userData: SPUserData) {
-        isInitialized.complete(result: userData)
-        flutterAPI?.callOnConsentReady(userData: userData)
-    }
+  public func onConsentReady(userData: SPUserData) {
+    isInitialized.complete(result: userData)
+    flutterAPI?.callOnConsentReady(userData: userData)
+  }
 
-    public func onError(error: SPError) {
-        flutterAPI?.callOnError(error: error)
-    }
+  public func onError(error: SPError) {
+    flutterAPI?.callOnError(error: error)
+  }
 
-    public func onSPNativeMessageReady(_: SPNativeMessage) {
-        logger.debug(message: "onSPNativeMessageReady")
-    }
+  public func onSPNativeMessageReady(_: SPNativeMessage) {
+    logger.debug(message: "onSPNativeMessageReady")
+  }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/SourcepointUnifiedCmpPlugin.swift
@@ -6,146 +6,142 @@ import UIKit
 extension FlutterError: Error {}
 
 public class SourcepointUnifiedCmpPlugin: UIViewController, FlutterPlugin,
-    SourcepointUnifiedCmpHostApi
-{
-    public static var instance: SourcepointUnifiedCmpPlugin?
-    private var consentManager: SPSDK!
-    private var isInitialized: Completer<SPUserData> = .init()
-    private var flutterAPI: SourcepointFlutterApi?
+  SourcepointUnifiedCmpHostApi {
+  public static var instance: SourcepointUnifiedCmpPlugin?
+  private var consentManager: SPSDK!
+  private var isInitialized: Completer<SPUserData> = .init()
+  private var flutterAPI: SourcepointFlutterApi?
 
-    func loadMessage(
-        accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
-        messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
-        messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
-        completion: @escaping (Result<HostAPISPConsent, Error>) -> Void
-    ) {
-        consentManager = SPConsentManager(
-            accountId: Int(accountId),
-            propertyId: Int(propertyId),
-            propertyName: try! SPPropertyName(propertyName),
-            campaigns: SPCampaigns(
-                gdpr: runGDPRCampaign ? SPCampaign() : nil,
-                ccpa: runCCPACampaign ? SPCampaign() : nil,
-                environment: campaignsEnv.toSPCampaignEnv()
-            ),
-            delegate: self
-        )
-        consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
-        consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
-        consentManager.loadMessage()
-        isInitialized.setCompletionHandler { [completion] result in
-            completion(.success(result.toHostAPISPConsent()))
-        }
+  func loadMessage(accountId: Int64, propertyId: Int64, propertyName: String, pmId _: String,
+                   messageLanguage: HostAPIMessageLanguage, campaignsEnv: HostAPICampaignsEnv,
+                   messageTimeout: Int64, runGDPRCampaign: Bool, runCCPACampaign: Bool,
+                   completion: @escaping (Result<HostAPISPConsent, Error>) -> Void) {
+    consentManager = SPConsentManager(
+      accountId: Int(accountId),
+      propertyId: Int(propertyId),
+      propertyName: try! SPPropertyName(propertyName),
+      campaigns: SPCampaigns(
+        gdpr: runGDPRCampaign ? SPCampaign() : nil,
+        ccpa: runCCPACampaign ? SPCampaign() : nil,
+        environment: campaignsEnv.toSPCampaignEnv()
+      ),
+      delegate: self
+    )
+    consentManager.messageLanguage = messageLanguage.toSPMessageLanguage()
+    consentManager.messageTimeoutInSeconds = Double(messageTimeout) / 1000
+    consentManager.loadMessage()
+    isInitialized.setCompletionHandler { [completion] result in
+      completion(.success(result.toHostAPISPConsent()))
     }
+  }
 
-    func loadPrivacyManager(
-        pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
-        messageType _: HostAPIMessageType,
-        completion _: @escaping (Result<Void, Error>) -> Void
-    ) {
-        switch campaignType {
-        case HostAPICampaignType.gdpr:
-            consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-        case HostAPICampaignType.ccpa:
-            consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-        case HostAPICampaignType.usnat:
-            consentManager.loadUSNatPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-        case HostAPICampaignType.globalcmp:
-            consentManager.loadGlobalCmpPrivacyManager(
-                withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
-        case HostAPICampaignType.preferences:
-            consentManager.loadPreferenceCenter(withId: pmId)
-        case HostAPICampaignType.ios14:
-            break
-        case HostAPICampaignType.unknown:
-            break
-        }
+  func loadPrivacyManager(pmId: String, pmTab: HostAPIPMTab, campaignType: HostAPICampaignType,
+                          messageType _: HostAPIMessageType,
+                          completion _: @escaping (Result<Void, Error>) -> Void) {
+    switch campaignType {
+    case HostAPICampaignType.gdpr:
+      consentManager.loadGDPRPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    case HostAPICampaignType.ccpa:
+      consentManager.loadCCPAPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    case HostAPICampaignType.usnat:
+      consentManager.loadUSNatPrivacyManager(withId: pmId, tab: pmTab.toSPPrivacyManagerTab())
+    case HostAPICampaignType.globalcmp:
+      consentManager.loadGlobalCmpPrivacyManager(
+        withId: pmId, tab: pmTab.toSPPrivacyManagerTab()
+      )
+    case HostAPICampaignType.preferences:
+      consentManager.loadPreferenceCenter(withId: pmId)
+    case HostAPICampaignType.ios14:
+      break
+    case HostAPICampaignType.unknown:
+      break
     }
+  }
 
-    public static func register(with registrar: FlutterPluginRegistrar) {
-        instance = SourcepointUnifiedCmpPlugin()
-        instance?.onRegister(registrar)
-    }
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    instance = SourcepointUnifiedCmpPlugin()
+    instance?.onRegister(registrar)
+  }
 
-    public func onRegister(_ registrar: FlutterPluginRegistrar) {
-        let messenger: FlutterBinaryMessenger = registrar.messenger()
-        SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
-        flutterAPI = SourcepointFlutterApi(messenger: messenger)
-    }
+  public func onRegister(_ registrar: FlutterPluginRegistrar) {
+    let messenger: FlutterBinaryMessenger = registrar.messenger()
+    SourcepointUnifiedCmpHostApiSetup.setUp(binaryMessenger: messenger, api: self)
+    flutterAPI = SourcepointFlutterApi(messenger: messenger)
+  }
 }
 
 private class SourcepointFlutterApi {
-    private var flutterAPI: SourcepointUnifiedCmpFlutterApi
+  private var flutterAPI: SourcepointUnifiedCmpFlutterApi
 
-    init(messenger: FlutterBinaryMessenger) {
-        flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
-    }
+  init(messenger: FlutterBinaryMessenger) {
+    flutterAPI = SourcepointUnifiedCmpFlutterApi(binaryMessenger: messenger)
+  }
 
-    func callOnConsentReady(userData: SPUserData) {
-        flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
-    }
+  func callOnConsentReady(userData: SPUserData) {
+    flutterAPI.onConsentReady(consent: userData.toHostAPISPConsent()) { _ in }
+  }
 
-    func callOnUIReady(controller: UIViewController) {
-        flutterAPI.onUIReady { _ in }
-    }
+  func callOnUIReady(controller: UIViewController) {
+    flutterAPI.onUIReady { _ in }
+  }
 
-    func callOnAction(controller: UIViewController, action: SPAction) {
-        flutterAPI.onAction(
-            consentAction: action.toHostAPIConsentAction()
-        ) { _ in }
-    }
+  func callOnAction(controller: UIViewController, action: SPAction) {
+    flutterAPI.onAction(
+      consentAction: action.toHostAPIConsentAction()
+    ) { _ in }
+  }
 
-    func callOnUIFinished(controller: UIViewController) {
-        flutterAPI.onUIFinished { _ in }
-    }
+  func callOnUIFinished(controller: UIViewController) {
+    flutterAPI.onUIFinished { _ in }
+  }
 
-    func callOnSpFinished(userData: SPUserData) {
-        flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
-    }
+  func callOnSpFinished(userData: SPUserData) {
+    flutterAPI.onSpFinished(consent: userData.toHostAPISPConsent()) { _ in }
+  }
 
-    func callOnError(error: SPError) {
-        flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
-    }
+  func callOnError(error: SPError) {
+    flutterAPI.onError(error: error.toHostAPISPError()) { _ in }
+  }
 }
 
 extension SourcepointUnifiedCmpPlugin: SPDelegate {
-    public func onSPUIReady(_ controller: UIViewController) {
-        controller.modalPresentationStyle = .overFullScreen
-        DispatchQueue.main.async {
-            guard
-                let topVC = getTopMostViewController(),
-                topVC !== controller,
-                controller.presentingViewController == nil,
-                !controller.isBeingPresented
-            else { return }
-            topVC.present(controller, animated: true)
-        }
-        flutterAPI?.callOnUIReady(controller: controller)
+  public func onSPUIReady(_ controller: UIViewController) {
+    controller.modalPresentationStyle = .overFullScreen
+    DispatchQueue.main.async {
+      guard
+        let topVC = getTopMostViewController(),
+        topVC !== controller,
+        controller.presentingViewController == nil,
+        !controller.isBeingPresented
+      else { return }
+      topVC.present(controller, animated: true)
     }
+    flutterAPI?.callOnUIReady(controller: controller)
+  }
 
-    public func onAction(_ action: SPAction, from controller: UIViewController) {
-        flutterAPI?.callOnAction(controller: controller, action: action)
-    }
+  public func onAction(_ action: SPAction, from controller: UIViewController) {
+    flutterAPI?.callOnAction(controller: controller, action: action)
+  }
 
-    public func onSPUIFinished(_ controller: UIViewController) {
-        getTopMostViewController()?.dismiss(animated: true)
-        flutterAPI?.callOnUIFinished(controller: controller)
-    }
+  public func onSPUIFinished(_ controller: UIViewController) {
+    getTopMostViewController()?.dismiss(animated: true)
+    flutterAPI?.callOnUIFinished(controller: controller)
+  }
 
-    public func onSPFinished(userData: SPUserData) {
-        flutterAPI?.callOnSpFinished(userData: userData)
-    }
+  public func onSPFinished(userData: SPUserData) {
+    flutterAPI?.callOnSpFinished(userData: userData)
+  }
 
-    public func onConsentReady(userData: SPUserData) {
-        isInitialized.complete(result: userData)
-        flutterAPI?.callOnConsentReady(userData: userData)
-    }
+  public func onConsentReady(userData: SPUserData) {
+    isInitialized.complete(result: userData)
+    flutterAPI?.callOnConsentReady(userData: userData)
+  }
 
-    public func onError(error: SPError) {
-        flutterAPI?.callOnError(error: error)
-    }
+  public func onError(error: SPError) {
+    flutterAPI?.callOnError(error: error)
+  }
 
-    public func onSPNativeMessageReady(_: SPNativeMessage) {
-        logger.debug(message: "onSPNativeMessageReady")
-    }
+  public func onSPNativeMessageReady(_: SPNativeMessage) {
+    logger.debug(message: "onSPNativeMessageReady")
+  }
 }

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
@@ -190,7 +190,11 @@ enum HostAPIPMTab: Int {
 enum HostAPICampaignType: Int {
   case gdpr = 0
   case ccpa = 1
-  case unknown = 2
+  case usnat = 2
+  case ios14 = 3
+  case globalcmp = 4
+  case preferences = 5
+  case unknown = 6
 }
 
 enum HostAPIMessageType: Int {

--- a/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
+++ b/packages/sourcepoint_unified_cmp_ios/ios/sourcepoint_unified_cmp_ios/Sources/sourcepoint_unified_cmp_ios/pigeons/SourcepointUnifiedCmp.g.swift
@@ -190,6 +190,7 @@ enum HostAPIPMTab: Int {
 enum HostAPICampaignType: Int {
   case gdpr = 0
   case ccpa = 1
+  case unknown = 2
 }
 
 enum HostAPIMessageType: Int {

--- a/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
@@ -55,6 +55,8 @@ extension on messages.HostAPICampaignType {
         return CampaignType.gdpr;
       case messages.HostAPICampaignType.ccpa:
         return CampaignType.ccpa;
+      case messages.HostAPICampaignType.unknown:
+        return CampaignType.unknown;
     }
   }
 }
@@ -204,6 +206,8 @@ extension on CampaignType {
       case CampaignType.usnat:
         // FIXME: Handle this case.
         throw UnimplementedError();
+      case CampaignType.unknown:
+        return messages.HostAPICampaignType.unknown;
     }
   }
 }

--- a/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/sourcepoint_unified_cmp_ios.dart
@@ -55,6 +55,14 @@ extension on messages.HostAPICampaignType {
         return CampaignType.gdpr;
       case messages.HostAPICampaignType.ccpa:
         return CampaignType.ccpa;
+      case messages.HostAPICampaignType.usnat:
+        return CampaignType.usnat;
+      case messages.HostAPICampaignType.ios14:
+        return CampaignType.ios14;
+      case messages.HostAPICampaignType.globalcmp:
+        return CampaignType.globalcmp;
+      case messages.HostAPICampaignType.preferences:
+        return CampaignType.preferences;
       case messages.HostAPICampaignType.unknown:
         return CampaignType.unknown;
     }
@@ -204,8 +212,13 @@ extension on CampaignType {
       case CampaignType.ccpa:
         return messages.HostAPICampaignType.ccpa;
       case CampaignType.usnat:
-        // FIXME: Handle this case.
-        throw UnimplementedError();
+        return messages.HostAPICampaignType.usnat;
+      case CampaignType.ios14:
+        return messages.HostAPICampaignType.ios14;
+      case CampaignType.globalcmp:
+        return messages.HostAPICampaignType.globalcmp;
+      case CampaignType.preferences:
+        return messages.HostAPICampaignType.preferences;
       case CampaignType.unknown:
         return messages.HostAPICampaignType.unknown;
     }

--- a/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
@@ -113,7 +113,15 @@ int _deepHash(Object? value) {
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa, unknown }
+enum HostAPICampaignType {
+  gdpr,
+  ccpa,
+  usnat,
+  ios14,
+  globalcmp,
+  preferences,
+  unknown,
+}
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
+++ b/packages/sourcepoint_unified_cmp_ios/lib/src/messages.g.dart
@@ -113,7 +113,7 @@ int _deepHash(Object? value) {
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa }
+enum HostAPICampaignType { gdpr, ccpa, unknown }
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
@@ -4,7 +4,15 @@ import 'package:pigeon/pigeon.dart';
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa, unknown }
+enum HostAPICampaignType {
+  gdpr,
+  ccpa,
+  usnat,
+  ios14,
+  globalcmp,
+  preferences,
+  unknown,
+}
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
+++ b/packages/sourcepoint_unified_cmp_ios/pigeons/messages.dart
@@ -4,7 +4,7 @@ import 'package:pigeon/pigeon.dart';
 
 enum HostAPIPMTab { defaults, purposes, vendors, features }
 
-enum HostAPICampaignType { gdpr, ccpa }
+enum HostAPICampaignType { gdpr, ccpa, unknown }
 
 enum HostAPIMessageType { mobile, ott, legacyOtt }
 

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
@@ -108,6 +108,12 @@ enum CampaignType {
   /// mobile devices. Click here to learn more about implementing U.S.
   /// Multi-State Privacy on OTT.
   ///usnat
+
+  /// Unknown campaign type - used as a fallback when the native SDK returns
+  /// a campaign type that is not yet supported (e.g. ios14 or other
+  /// iOS-specific campaign types). This prevents a crash on iOS when the
+  /// user cancels the privacy consent modal.
+  unknown,
   // TODO(thekorn): add missing iOs specific campaigns
 }
 

--- a/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/lib/src/types.dart
@@ -100,21 +100,23 @@ enum CampaignType {
   /// Represents the United States National Advertising Initiative (USNAT).
   usnat,
 
-  /// Used if your property runs a U.S. Multi-State Privacy campaign.
-  /// Please do not attempt to utilize both CCPA and USNAT simultaneously as
-  /// this poses a compliance risk for your organization.
-  ///
-  /// This campaign type should only be implemented via the config object on
-  /// mobile devices. Click here to learn more about implementing U.S.
-  /// Multi-State Privacy on OTT.
-  ///usnat
+  /// iOS 14+ App Tracking Transparency campaign type (iOS only).
+  /// There is no Privacy Manager method for this type — it is a no-op
+  /// when `loadPrivacyManager` is called.
+  ios14,
+
+  /// Global CMP campaign type. Used when the property runs a Global CMP
+  /// campaign (available on both iOS and Android).
+  globalcmp,
+
+  /// Preference Center campaign type. Loads the Preference Center instead
+  /// of a standard Privacy Manager (available on both iOS and Android).
+  preferences,
 
   /// Unknown campaign type - used as a fallback when the native SDK returns
-  /// a campaign type that is not yet supported (e.g. ios14 or other
-  /// iOS-specific campaign types). This prevents a crash on iOS when the
-  /// user cancels the privacy consent modal.
+  /// a campaign type that is not yet supported. This prevents a crash when
+  /// the user cancels the privacy consent modal.
   unknown,
-  // TODO(thekorn): add missing iOs specific campaigns
 }
 
 /// message type - android only


### PR DESCRIPTION
## Description

Prevents a crash on iOS when the Sourcepoint SDK returns an unrecognized campaign type (e.g. when the user taps **Cancel** on the privacy consent modal, which can fire an action with an `ios14` or other unmapped `SPCampaignType`).

Closes #259.

## Root Cause

`SPAction.toHostAPIConsentAction()` used `try!` for both `toHostAPIActionType()` and `toHostAPICampaignType()`. When the iOS SDK delivers a `PMCancel` action with a campaign type that is not mapped (e.g. `ios14`), `toHostAPICampaignType()` would throw `NotImplementedError.notImplemented`, and the force-try would propagate an unhandled exception, crashing the app.

## Changes

| File | Change |
|------|--------|
| `platform_interface/lib/src/types.dart` | Add `CampaignType.unknown` to the shared enum |
| `ios/pigeons/messages.dart` | Add `unknown` to `HostAPICampaignType` (Pigeon definition) |
| `ios/lib/src/messages.g.dart` *(regenerated)* | `HostAPICampaignType` now includes `unknown` |
| `ios/.../pigeons/SourcepointUnifiedCmp.g.swift` *(regenerated)* | `HostAPICampaignType` now includes `case unknown = 2` |
| `SourcepointUnifiedCmpData.swift` | Replace `try! campaignType.toHostAPICampaignType()` with non-throwing call; replace `try! type.toHostAPIActionType()` with `try?/fallback`; change `SPCampaignType.toHostAPICampaignType()` to non-throwing with `default → .unknown` |
| `SourcepointUnifiedCmpPlugin.swift` | Add `case .unknown: break` to exhaustive switch in `loadPrivacyManager` |
| `ios/lib/sourcepoint_unified_cmp_ios.dart` | Handle `unknown` in both `HostAPICampaignType → CampaignType` and `CampaignType → HostAPICampaignType` extensions |
| `android/lib/sourcepoint_unified_cmp_android.dart` | Add `CampaignType.unknown → throw UnimplementedError` (iOS-only value) |

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Validation

- `melos run analyze` → no issues
- `fvm flutter test --coverage` in `sourcepoint_unified_cmp_ios`, `sourcepoint_unified_cmp_android`, and `sourcepoint_unified_cmp_platform_interface` → all tests pass