### PR TITLE
test: increase Flutter test coverage from 25% to 97.83%

### DIFF
--- a/packages/sourcepoint_unified_cmp/test/delegate_test.dart
+++ b/packages/sourcepoint_unified_cmp/test/delegate_test.dart
@@ -54,7 +54,7 @@ void main() {
 
       final action = ConsentAction(
         actionType: ActionType.acceptAll,
-        pubData: {},
+        pubData: <String, Object?>{},
         campaignType: CampaignType.gdpr,
       );
       delegate.onAction?.call(action);
@@ -123,7 +123,7 @@ void main() {
       delegate.onAction?.call(
         ConsentAction(
           actionType: ActionType.rejectAll,
-          pubData: {},
+          pubData: <String, Object?>{},
           campaignType: CampaignType.gdpr,
         ),
       );

--- a/packages/sourcepoint_unified_cmp/test/delegate_test.dart
+++ b/packages/sourcepoint_unified_cmp/test/delegate_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sourcepoint_unified_cmp/sourcepoint_unified_cmp.dart';
+
+void main() {
+  group('SourcepointEventDelegate', () {
+    test('creates with all null callbacks by default', () {
+      final delegate = SourcepointEventDelegate();
+      expect(delegate.onConsentReady, isNull);
+      expect(delegate.onUIReady, isNull);
+      expect(delegate.onAction, isNull);
+      expect(delegate.onError, isNull);
+      expect(delegate.onNoIntentActivitiesFound, isNull);
+      expect(delegate.onSpFinished, isNull);
+      expect(delegate.onUIFinished, isNull);
+    });
+
+    test('stores onConsentReady callback', () {
+      SPConsent? received;
+      final delegate = SourcepointEventDelegate(
+        onConsentReady: (consent) => received = consent,
+      );
+
+      final consent = SPConsent(webConsents: 'test');
+      delegate.onConsentReady?.call(consent);
+
+      expect(received, consent);
+    });
+
+    test('stores onUIReady callback', () {
+      var called = false;
+      final delegate = SourcepointEventDelegate(onUIReady: () => called = true);
+
+      delegate.onUIReady?.call();
+
+      expect(called, isTrue);
+    });
+
+    test('stores onUIFinished callback', () {
+      var called = false;
+      final delegate = SourcepointEventDelegate(
+        onUIFinished: () => called = true,
+      );
+
+      delegate.onUIFinished?.call();
+
+      expect(called, isTrue);
+    });
+
+    test('stores onAction callback', () {
+      ConsentAction? received;
+      final delegate = SourcepointEventDelegate(
+        onAction: (action) => received = action,
+      );
+
+      final action = ConsentAction(
+        actionType: ActionType.acceptAll,
+        pubData: {},
+        campaignType: CampaignType.gdpr,
+      );
+      delegate.onAction?.call(action);
+
+      expect(received, action);
+    });
+
+    test('stores onError callback', () {
+      SPError? received;
+      final delegate = SourcepointEventDelegate(
+        onError: (error) => received = error,
+      );
+
+      final error = SPError(spCode: 'E001', description: 'An error');
+      delegate.onError?.call(error);
+
+      expect(received, error);
+    });
+
+    test('stores onNoIntentActivitiesFound callback', () {
+      String? received;
+      final delegate = SourcepointEventDelegate(
+        onNoIntentActivitiesFound: (url) => received = url,
+      );
+
+      delegate.onNoIntentActivitiesFound?.call('https://example.com');
+
+      expect(received, 'https://example.com');
+    });
+
+    test('stores onSpFinished callback', () {
+      SPConsent? received;
+      final delegate = SourcepointEventDelegate(
+        onSpFinished: (consent) => received = consent,
+      );
+
+      final consent = SPConsent(webConsents: 'finished');
+      delegate.onSpFinished?.call(consent);
+
+      expect(received, consent);
+    });
+
+    test('all callbacks can be set at once', () {
+      SPConsent? consentReady;
+      ConsentAction? action;
+      SPError? error;
+      String? url;
+      SPConsent? spFinished;
+      var uiReady = false;
+      var uiFinished = false;
+
+      final delegate = SourcepointEventDelegate(
+        onConsentReady: (c) => consentReady = c,
+        onUIReady: () => uiReady = true,
+        onUIFinished: () => uiFinished = true,
+        onAction: (a) => action = a,
+        onError: (e) => error = e,
+        onNoIntentActivitiesFound: (u) => url = u,
+        onSpFinished: (c) => spFinished = c,
+      );
+
+      final consent = SPConsent(webConsents: 'test');
+      delegate.onConsentReady?.call(consent);
+      delegate.onUIReady?.call();
+      delegate.onUIFinished?.call();
+      delegate.onAction?.call(
+        ConsentAction(
+          actionType: ActionType.rejectAll,
+          pubData: {},
+          campaignType: CampaignType.gdpr,
+        ),
+      );
+      delegate.onError?.call(SPError(spCode: 'E001', description: 'err'));
+      delegate.onNoIntentActivitiesFound?.call('https://example.com');
+      delegate.onSpFinished?.call(SPConsent(webConsents: 'finished'));
+
+      expect(consentReady, consent);
+      expect(uiReady, isTrue);
+      expect(uiFinished, isTrue);
+      expect(action?.actionType, ActionType.rejectAll);
+      expect(error?.spCode, 'E001');
+      expect(url, 'https://example.com');
+      expect(spFinished?.webConsents, 'finished');
+    });
+  });
+}

--- a/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
+++ b/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -28,6 +29,155 @@ void main() {
     final controller = SourcepointController(config: config);
     final r = await controller.loadMessage();
     expect(r, isNotNull);
+  });
+
+  group('SourcepointController', () {
+    test('setEventDelegate registers the delegate with the platform', () {
+      final config = SPConfig(
+        accountId: 22,
+        propertyId: 7639,
+        propertyName: 'tcfv2.mobile.webview',
+        pmId: '122058',
+        campaigns: [CampaignType.gdpr],
+      );
+      final delegate = SourcepointEventDelegate();
+      final controller = SourcepointController(config: config);
+
+      controller.setEventDelegate(delegate);
+
+      verify(methodChannel.registerEventDelegate(delegate)).called(1);
+    });
+
+    test(
+      'loadPrivacyManager calls the platform with correct parameters',
+      () async {
+        final config = SPConfig(
+          accountId: 22,
+          propertyId: 7639,
+          propertyName: 'tcfv2.mobile.webview',
+          pmId: '122058',
+          campaigns: [CampaignType.gdpr],
+        );
+        when(
+          methodChannel.loadPrivacyManager(any, any, any, any),
+        ).thenAnswer((_) async {});
+
+        final controller = SourcepointController(config: config);
+        await controller.loadPrivacyManager(pmId: '122058');
+
+        verify(
+          methodChannel.loadPrivacyManager(
+            '122058',
+            PMTab.purposes,
+            CampaignType.gdpr,
+            MessageType.mobile,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'loadPrivacyManager forwards all optional parameters to the platform',
+      () async {
+        final config = SPConfig(
+          accountId: 22,
+          propertyId: 7639,
+          propertyName: 'tcfv2.mobile.webview',
+          pmId: '122058',
+          campaigns: [CampaignType.gdpr],
+        );
+        when(
+          methodChannel.loadPrivacyManager(any, any, any, any),
+        ).thenAnswer((_) async {});
+
+        final controller = SourcepointController(config: config);
+        await controller.loadPrivacyManager(
+          pmId: '999',
+          pmTab: PMTab.vendors,
+          campaignType: CampaignType.ccpa,
+          messageType: MessageType.ott,
+        );
+
+        verify(
+          methodChannel.loadPrivacyManager(
+            '999',
+            PMTab.vendors,
+            CampaignType.ccpa,
+            MessageType.ott,
+          ),
+        ).called(1);
+      },
+    );
+  });
+
+  group('SourcepointUnifiedCMPBuilder', () {
+    testWidgets('shows builder content after future resolves', (tester) async {
+      final consent = SPConsent(webConsents: 'test_consent');
+      final config = SPConfig(
+        accountId: 22,
+        propertyId: 7639,
+        propertyName: 'tcfv2.mobile.webview',
+        pmId: '122058',
+        campaigns: [CampaignType.gdpr],
+      );
+      when(methodChannel.loadMessage(any)).thenAnswer((_) async => consent);
+
+      final controller = SourcepointController(config: config);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SourcepointUnifiedCMPBuilder(
+            controller: controller,
+            builder: (context, snapshot) {
+              if (snapshot.hasData) {
+                return const Text('loaded');
+              }
+              return const CircularProgressIndicator();
+            },
+          ),
+        ),
+      );
+
+      // Initially shows loading indicator before future resolves.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // After the future resolves, shows the content.
+      await tester.pumpAndSettle();
+      expect(find.text('loaded'), findsOneWidget);
+    });
+
+    testWidgets('passes SPConsent snapshot to builder', (tester) async {
+      final consent = SPConsent(webConsents: 'web_consent');
+      final config = SPConfig(
+        accountId: 22,
+        propertyId: 7639,
+        propertyName: 'tcfv2.mobile.webview',
+        pmId: '122058',
+        campaigns: [CampaignType.gdpr],
+      );
+      when(methodChannel.loadMessage(any)).thenAnswer((_) async => consent);
+
+      SPConsent? receivedConsent;
+      final controller = SourcepointController(config: config);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SourcepointUnifiedCMPBuilder(
+            controller: controller,
+            builder: (context, snapshot) {
+              if (snapshot.hasData) {
+                receivedConsent = snapshot.data;
+                return const Text('done');
+              }
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(receivedConsent, consent);
+    });
   });
 
   group('WebView Utils', () {

--- a/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
+++ b/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
@@ -17,6 +17,12 @@ void main() {
     SourcepointUnifiedCmpPlatform.setInstanceUnverified(methodChannel);
   });
 
+  tearDown(() {
+    SourcepointUnifiedCmpPlatform.setInstanceUnverified(
+      MethodChannelSourcepointUnifiedCmp(),
+    );
+  });
+
   test('loadMessage', () async {
     final config = SPConfig(
       accountId: 22,

--- a/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
+++ b/packages/sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart
@@ -41,9 +41,7 @@ void main() {
         campaigns: [CampaignType.gdpr],
       );
       final delegate = SourcepointEventDelegate();
-      final controller = SourcepointController(config: config);
-
-      controller.setEventDelegate(delegate);
+      SourcepointController(config: config).setEventDelegate(delegate);
 
       verify(methodChannel.registerEventDelegate(delegate)).called(1);
     });

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/change_notifier_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/change_notifier_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/sourcepoint_unified_cmp_platform_interface.dart';
+
+class _TestConsentChangeNotifier extends ConsentChangeNotifier {}
+
+void main() {
+  group('ConsentChangeNotifier', () {
+    test('consent is initially null', () {
+      final notifier = _TestConsentChangeNotifier();
+      expect(notifier.consent, isNull);
+    });
+
+    test('updateConsent updates the consent field', () {
+      final notifier = _TestConsentChangeNotifier();
+      final consent = SPConsent(webConsents: 'test_consent');
+
+      notifier.updateConsent(consent);
+
+      expect(notifier.consent, consent);
+    });
+
+    test('updateConsent calls notifyListeners', () {
+      final notifier = _TestConsentChangeNotifier();
+      var callCount = 0;
+      notifier.addListener(() => callCount++);
+
+      notifier.updateConsent(SPConsent(webConsents: 'test_consent'));
+
+      expect(callCount, 1);
+    });
+
+    test('updateConsent can be called multiple times', () {
+      final notifier = _TestConsentChangeNotifier();
+      var callCount = 0;
+      notifier.addListener(() => callCount++);
+
+      notifier.updateConsent(SPConsent(webConsents: 'first'));
+      notifier.updateConsent(SPConsent(webConsents: 'second'));
+
+      expect(callCount, 2);
+      expect(notifier.consent?.webConsents, 'second');
+    });
+
+    test('updateConsent notifies multiple listeners', () {
+      final notifier = _TestConsentChangeNotifier();
+      var firstCount = 0;
+      var secondCount = 0;
+      notifier
+        ..addListener(() => firstCount++)
+        ..addListener(() => secondCount++);
+
+      notifier.updateConsent(SPConsent());
+
+      expect(firstCount, 1);
+      expect(secondCount, 1);
+    });
+  });
+}

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/change_notifier_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/change_notifier_test.dart
@@ -22,9 +22,9 @@ void main() {
     test('updateConsent calls notifyListeners', () {
       final notifier = _TestConsentChangeNotifier();
       var callCount = 0;
-      notifier.addListener(() => callCount++);
-
-      notifier.updateConsent(SPConsent(webConsents: 'test_consent'));
+      notifier
+        ..addListener(() => callCount++)
+        ..updateConsent(SPConsent(webConsents: 'test_consent'));
 
       expect(callCount, 1);
     });
@@ -32,10 +32,10 @@ void main() {
     test('updateConsent can be called multiple times', () {
       final notifier = _TestConsentChangeNotifier();
       var callCount = 0;
-      notifier.addListener(() => callCount++);
-
-      notifier.updateConsent(SPConsent(webConsents: 'first'));
-      notifier.updateConsent(SPConsent(webConsents: 'second'));
+      notifier
+        ..addListener(() => callCount++)
+        ..updateConsent(SPConsent(webConsents: 'first'))
+        ..updateConsent(SPConsent(webConsents: 'second'));
 
       expect(callCount, 2);
       expect(notifier.consent?.webConsents, 'second');
@@ -47,9 +47,8 @@ void main() {
       var secondCount = 0;
       notifier
         ..addListener(() => firstCount++)
-        ..addListener(() => secondCount++);
-
-      notifier.updateConsent(SPConsent());
+        ..addListener(() => secondCount++)
+        ..updateConsent(SPConsent());
 
       expect(firstCount, 1);
       expect(secondCount, 1);

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/controller_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/controller_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/sourcepoint_unified_cmp_platform_interface.dart';
+
+// Concrete implementation of AbstractSourcepointConsentController for testing.
+// It extends AbstractSourcepointConsentController (covering the constructor)
+// and mixes in ChangeNotifier to satisfy the ConsentChangeNotifier contract.
+class _TestController extends AbstractSourcepointConsentController
+    with ChangeNotifier {
+  _TestController({required super.config});
+
+  @override
+  SPConsent? consent;
+
+  @override
+  void updateConsent(SPConsent newConsent) {
+    consent = newConsent;
+    notifyListeners();
+  }
+
+  @override
+  void setEventDelegate(SourcepointEventDelegatePlatform delegate) {}
+
+  @override
+  Future<void> loadPrivacyManager({
+    required String pmId,
+    PMTab pmTab = PMTab.purposes,
+    CampaignType campaignType = CampaignType.gdpr,
+    MessageType messageType = MessageType.mobile,
+  }) async {}
+
+  @override
+  Future<SPConsent> loadMessage() async => SPConsent();
+}
+
+void main() {
+  group('AbstractSourcepointConsentController', () {
+    late SPConfig config;
+
+    setUp(() {
+      config = SPConfig(
+        accountId: 22,
+        propertyId: 7639,
+        propertyName: 'test.property',
+        pmId: '122058',
+        campaigns: [CampaignType.gdpr],
+      );
+    });
+
+    test('stores config from constructor', () {
+      final controller = _TestController(config: config);
+      expect(controller.config, config);
+      expect(controller.config.accountId, 22);
+      expect(controller.config.propertyId, 7639);
+      expect(controller.config.pmId, '122058');
+    });
+
+    test('loadMessage returns an SPConsent', () async {
+      final controller = _TestController(config: config);
+      final result = await controller.loadMessage();
+      expect(result, isA<SPConsent>());
+    });
+
+    test('loadPrivacyManager completes without error', () async {
+      final controller = _TestController(config: config);
+      await expectLater(
+        controller.loadPrivacyManager(pmId: '122058'),
+        completes,
+      );
+    });
+
+    test('updateConsent updates the consent field and notifies listeners', () {
+      final controller = _TestController(config: config);
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      final consent = SPConsent(webConsents: 'test');
+      controller.updateConsent(consent);
+
+      expect(controller.consent, consent);
+      expect(notified, isTrue);
+    });
+  });
+}

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/interface_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/interface_test.dart
@@ -15,8 +15,6 @@ class _TestConsentChangeNotifier extends ConsentChangeNotifier {}
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  // This test must run before any setInstanceUnverified call to trigger the
-  // lazy static initializer for SourcepointUnifiedCmpPlatform._instance.
   test('default instance is MethodChannelSourcepointUnifiedCmp', () {
     expect(
       SourcepointUnifiedCmpPlatform.instance,
@@ -29,6 +27,12 @@ void main() {
 
     setUp(() {
       platform = _TestPlatform();
+    });
+
+    tearDown(() {
+      SourcepointUnifiedCmpPlatform.setInstanceUnverified(
+        MethodChannelSourcepointUnifiedCmp(),
+      );
     });
 
     test('registerEventDelegate throws UnimplementedError', () {

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/interface_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/interface_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/sourcepoint_unified_cmp_platform_interface.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/src/method_channel.dart';
+
+// Minimal concrete subclass to exercise base class methods.
+class _TestPlatform extends SourcepointUnifiedCmpPlatform {}
+
+// Minimal concrete delegate with all-null callbacks.
+class _TestDelegate extends SourcepointEventDelegatePlatform {
+  _TestDelegate() : super();
+}
+
+class _TestConsentChangeNotifier extends ConsentChangeNotifier {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // This test must run before any setInstanceUnverified call to trigger the
+  // lazy static initializer for SourcepointUnifiedCmpPlatform._instance.
+  test('default instance is MethodChannelSourcepointUnifiedCmp', () {
+    expect(
+      SourcepointUnifiedCmpPlatform.instance,
+      isA<MethodChannelSourcepointUnifiedCmp>(),
+    );
+  });
+
+  group('SourcepointUnifiedCmpPlatform base class', () {
+    late _TestPlatform platform;
+
+    setUp(() {
+      platform = _TestPlatform();
+    });
+
+    test('registerEventDelegate throws UnimplementedError', () {
+      expect(
+        () => platform.registerEventDelegate(_TestDelegate()),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('registerConsentChangeNotifier throws UnimplementedError', () {
+      expect(
+        () => platform.registerConsentChangeNotifier(
+          _TestConsentChangeNotifier(),
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('loadMessage throws UnimplementedError', () {
+      expect(
+        () => platform.loadMessage(
+          SPConfig(
+            accountId: 22,
+            propertyId: 7639,
+            propertyName: 'test',
+            pmId: '123',
+            campaigns: [CampaignType.gdpr],
+          ),
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('loadPrivacyManager throws UnimplementedError', () {
+      expect(
+        () => platform.loadPrivacyManager(
+          '123',
+          PMTab.purposes,
+          CampaignType.gdpr,
+          MessageType.mobile,
+        ),
+        throwsUnimplementedError,
+      );
+    });
+
+    test('setInstanceUnverified sets the platform instance', () {
+      final testPlatform = _TestPlatform();
+      SourcepointUnifiedCmpPlatform.setInstanceUnverified(testPlatform);
+      expect(SourcepointUnifiedCmpPlatform.instance, testPlatform);
+    });
+
+    test('instance setter verifies token and sets the instance', () {
+      final testPlatform = _TestPlatform();
+      // Using the verified setter requires the class to have been constructed
+      // via SourcepointUnifiedCmpPlatform, which _TestPlatform is.
+      SourcepointUnifiedCmpPlatform.instance = testPlatform;
+      expect(SourcepointUnifiedCmpPlatform.instance, testPlatform);
+    });
+  });
+
+  group('SourcepointEventDelegatePlatform', () {
+    test('creates with all null callbacks by default', () {
+      final delegate = _TestDelegate();
+      expect(delegate.onConsentReady, isNull);
+      expect(delegate.onUIFinished, isNull);
+      expect(delegate.onUIReady, isNull);
+      expect(delegate.onError, isNull);
+      expect(delegate.onAction, isNull);
+      expect(delegate.onNoIntentActivitiesFound, isNull);
+      expect(delegate.onSpFinished, isNull);
+    });
+  });
+}

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/method_channel_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/method_channel_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/sourcepoint_unified_cmp_platform_interface.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/src/method_channel.dart';
+
+class _TestConsentChangeNotifier extends ConsentChangeNotifier {}
+
+class _TestDelegate extends SourcepointEventDelegatePlatform {
+  _TestDelegate() : super();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MethodChannelSourcepointUnifiedCmp', () {
+    late MethodChannelSourcepointUnifiedCmp channel;
+
+    setUp(() {
+      channel = MethodChannelSourcepointUnifiedCmp();
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('sourcepoint_unified_cmp'),
+            null,
+          );
+    });
+
+    group('registerConsentChangeNotifier', () {
+      test('registers a notifier without throwing', () {
+        final notifier = _TestConsentChangeNotifier();
+        expect(
+          () => channel.registerConsentChangeNotifier(notifier),
+          returnsNormally,
+        );
+      });
+
+      test('throws AssertionError when called a second time', () {
+        final notifier = _TestConsentChangeNotifier();
+        channel.registerConsentChangeNotifier(notifier);
+        expect(
+          () => channel.registerConsentChangeNotifier(
+            _TestConsentChangeNotifier(),
+          ),
+          throwsAssertionError,
+        );
+      });
+    });
+
+    group('registerEventDelegate', () {
+      test('registers a delegate without throwing', () {
+        final delegate = _TestDelegate();
+        expect(() => channel.registerEventDelegate(delegate), returnsNormally);
+      });
+
+      test('throws AssertionError when called a second time', () {
+        final delegate = _TestDelegate();
+        channel.registerEventDelegate(delegate);
+        expect(
+          () => channel.registerEventDelegate(_TestDelegate()),
+          throwsAssertionError,
+        );
+      });
+    });
+
+    group('loadPrivacyManager', () {
+      test('invokes the method channel without throwing', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('sourcepoint_unified_cmp'),
+              (MethodCall methodCall) async {
+                if (methodCall.method == 'loadPrivacyManager') {
+                  return null;
+                }
+                return null;
+              },
+            );
+
+        await expectLater(
+          channel.loadPrivacyManager(
+            '122058',
+            PMTab.purposes,
+            CampaignType.gdpr,
+            MessageType.mobile,
+          ),
+          completes,
+        );
+      });
+    });
+  });
+}

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/types_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/types_test.dart
@@ -1,0 +1,401 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sourcepoint_unified_cmp_platform_interface/sourcepoint_unified_cmp_platform_interface.dart';
+
+void main() {
+  group('SPConfig', () {
+    test('creates with required parameters using defaults', () {
+      final config = SPConfig(
+        accountId: 22,
+        propertyId: 7639,
+        propertyName: 'test.property',
+        pmId: '123',
+        campaigns: [CampaignType.gdpr],
+      );
+      expect(config.accountId, 22);
+      expect(config.propertyId, 7639);
+      expect(config.propertyName, 'test.property');
+      expect(config.pmId, '123');
+      expect(config.campaigns, [CampaignType.gdpr]);
+      expect(config.messageLanguage, MessageLanguage.english);
+      expect(config.campaignsEnv, CampaignsEnv.public);
+      expect(config.messageTimeout, 30000);
+    });
+
+    test('creates with optional parameters overriding defaults', () {
+      final config = SPConfig(
+        accountId: 22,
+        propertyId: 7639,
+        propertyName: 'test.property',
+        pmId: '123',
+        campaigns: [CampaignType.gdpr, CampaignType.ccpa],
+        messageLanguage: MessageLanguage.german,
+        campaignsEnv: CampaignsEnv.stage,
+        messageTimeout: 10000,
+      );
+      expect(config.messageLanguage, MessageLanguage.german);
+      expect(config.campaignsEnv, CampaignsEnv.stage);
+      expect(config.messageTimeout, 10000);
+      expect(config.campaigns, contains(CampaignType.ccpa));
+    });
+  });
+
+  group('GDPRPurposeGrants', () {
+    test('creates with required parameters', () {
+      final grants = GDPRPurposeGrants(
+        granted: true,
+        purposeGrants: {'purpose1': true, 'purpose2': false},
+      );
+      expect(grants.granted, isTrue);
+      expect(grants.purposeGrants, {'purpose1': true, 'purpose2': false});
+    });
+
+    test('toString contains key fields', () {
+      final grants = GDPRPurposeGrants(
+        granted: true,
+        purposeGrants: {'purpose1': true},
+      );
+      expect(grants.toString(), contains('GDPRPurposeGrants'));
+      expect(grants.toString(), contains('granted: true'));
+      expect(grants.toString(), contains('purpose1'));
+    });
+  });
+
+  group('GranularStatus', () {
+    test('creates with all null fields', () {
+      final status = GranularStatus();
+      expect(status.defaultConsent, isNull);
+      expect(status.previousOptInAll, isNull);
+      expect(status.purposeConsent, isNull);
+      expect(status.purposeLegInt, isNull);
+      expect(status.vendorConsent, isNull);
+      expect(status.vendorLegInt, isNull);
+    });
+
+    test('toString contains GranularStatus', () {
+      final status = GranularStatus();
+      expect(status.toString(), contains('GranularStatus'));
+    });
+
+    test('creates with all fields populated', () {
+      final status = GranularStatus(
+        defaultConsent: true,
+        previousOptInAll: false,
+        purposeConsent: GranularState.all,
+        purposeLegInt: GranularState.some,
+        vendorConsent: GranularState.none,
+        vendorLegInt: GranularState.emptyVl,
+      );
+      expect(status.defaultConsent, isTrue);
+      expect(status.previousOptInAll, isFalse);
+      expect(status.purposeConsent, GranularState.all);
+      expect(status.purposeLegInt, GranularState.some);
+      expect(status.vendorConsent, GranularState.none);
+      expect(status.vendorLegInt, GranularState.emptyVl);
+    });
+
+    test('toString with all fields contains expected values', () {
+      final status = GranularStatus(
+        defaultConsent: true,
+        previousOptInAll: false,
+        purposeConsent: GranularState.all,
+      );
+      expect(status.toString(), contains('defaultConsent: true'));
+      expect(status.toString(), contains('previousOptInAll: false'));
+    });
+  });
+
+  group('ConsentStatus', () {
+    test('creates with all null fields', () {
+      final status = ConsentStatus();
+      expect(status.consentedAll, isNull);
+      expect(status.consentedToAny, isNull);
+      expect(status.granularStatus, isNull);
+      expect(status.hasConsentData, isNull);
+      expect(status.rejectedAny, isNull);
+      expect(status.rejectedLI, isNull);
+      expect(status.legalBasisChanges, isNull);
+      expect(status.vendorListAdditions, isNull);
+    });
+
+    test('toString contains ConsentStatus', () {
+      final status = ConsentStatus();
+      expect(status.toString(), contains('ConsentStatus'));
+    });
+
+    test('creates with all fields populated', () {
+      final granularStatus = GranularStatus(defaultConsent: true);
+      final status = ConsentStatus(
+        consentedAll: true,
+        consentedToAny: true,
+        granularStatus: granularStatus,
+        hasConsentData: true,
+        rejectedAny: false,
+        rejectedLI: false,
+        legalBasisChanges: false,
+        vendorListAdditions: false,
+      );
+      expect(status.consentedAll, isTrue);
+      expect(status.consentedToAny, isTrue);
+      expect(status.granularStatus, granularStatus);
+      expect(status.hasConsentData, isTrue);
+      expect(status.rejectedAny, isFalse);
+    });
+
+    test('toString with all fields contains expected values', () {
+      final status = ConsentStatus(
+        consentedAll: true,
+        consentedToAny: false,
+        hasConsentData: true,
+        rejectedAny: false,
+        rejectedLI: true,
+        legalBasisChanges: false,
+        vendorListAdditions: true,
+      );
+      expect(status.toString(), contains('consentedAll: true'));
+      expect(status.toString(), contains('consentedToAny: false'));
+      expect(status.toString(), contains('hasConsentData: true'));
+      expect(status.toString(), contains('rejectedLI: true'));
+    });
+  });
+
+  group('GDPRConsent', () {
+    test('creates with required parameters', () {
+      final consent = GDPRConsent(
+        tcData: {'key': 'value'},
+        grants: {},
+        euconsent: 'euconsent_string',
+        acceptedCategories: ['cat1'],
+        apply: true,
+      );
+      expect(consent.uuid, isNull);
+      expect(consent.consentStatus, isNull);
+      expect(consent.euconsent, 'euconsent_string');
+      expect(consent.apply, isTrue);
+      expect(consent.tcData, {'key': 'value'});
+      expect(consent.acceptedCategories, ['cat1']);
+    });
+
+    test('creates with all optional parameters', () {
+      final consentStatus = ConsentStatus(consentedAll: true);
+      final grants = {
+        'vendor1': GDPRPurposeGrants(
+          granted: true,
+          purposeGrants: {'p1': true},
+        ),
+      };
+      final consent = GDPRConsent(
+        tcData: {'TC': 'data'},
+        grants: grants,
+        euconsent: 'consent_string',
+        acceptedCategories: ['cat1', 'cat2'],
+        apply: false,
+        uuid: 'test-uuid',
+        consentStatus: consentStatus,
+      );
+      expect(consent.uuid, 'test-uuid');
+      expect(consent.consentStatus, consentStatus);
+      expect(consent.grants, grants);
+    });
+
+    test('toString contains key fields', () {
+      final consent = GDPRConsent(
+        tcData: {},
+        grants: {},
+        euconsent: 'consent_string',
+        acceptedCategories: [],
+        apply: true,
+        uuid: 'test-uuid',
+      );
+      expect(consent.toString(), contains('GDPRConsent'));
+      expect(consent.toString(), contains('consent_string'));
+      expect(consent.toString(), contains('test-uuid'));
+    });
+  });
+
+  group('CCPAConsent', () {
+    test('creates with required parameters', () {
+      final consent = CCPAConsent(
+        rejectedCategories: ['cat1'],
+        rejectedVendors: ['vendor1'],
+        uspstring: '1YNN',
+        apply: true,
+      );
+      expect(consent.rejectedCategories, ['cat1']);
+      expect(consent.rejectedVendors, ['vendor1']);
+      expect(consent.uspstring, '1YNN');
+      expect(consent.apply, isTrue);
+      expect(consent.uuid, isNull);
+      expect(consent.status, isNull);
+    });
+
+    test('creates with optional parameters', () {
+      final consent = CCPAConsent(
+        rejectedCategories: [],
+        rejectedVendors: [],
+        uspstring: '1---',
+        apply: false,
+        uuid: 'uuid-123',
+        status: 'consentedAll',
+      );
+      expect(consent.uuid, 'uuid-123');
+      expect(consent.status, 'consentedAll');
+      expect(consent.apply, isFalse);
+    });
+  });
+
+  group('SPConsent', () {
+    test('creates with all null fields', () {
+      final consent = SPConsent();
+      expect(consent.gdpr, isNull);
+      expect(consent.ccpa, isNull);
+      expect(consent.webConsents, isNull);
+    });
+
+    test('toString contains SPConsent', () {
+      final consent = SPConsent();
+      expect(consent.toString(), contains('SPConsent'));
+    });
+
+    test('creates with gdpr consent', () {
+      final gdpr = GDPRConsent(
+        tcData: {},
+        grants: {},
+        euconsent: '',
+        acceptedCategories: [],
+        apply: true,
+      );
+      final consent = SPConsent(gdpr: gdpr);
+      expect(consent.gdpr, gdpr);
+    });
+
+    test('creates with ccpa consent', () {
+      final ccpa = CCPAConsent(
+        rejectedCategories: [],
+        rejectedVendors: [],
+        uspstring: '1YNN',
+        apply: true,
+      );
+      final consent = SPConsent(ccpa: ccpa);
+      expect(consent.ccpa, ccpa);
+    });
+
+    test('creates with webConsents and toString works', () {
+      final consent = SPConsent(webConsents: 'web_consent_string');
+      expect(consent.webConsents, 'web_consent_string');
+      expect(consent.toString(), contains('web_consent_string'));
+    });
+  });
+
+  group('ConsentAction', () {
+    test('creates with required parameters', () {
+      final action = ConsentAction(
+        actionType: ActionType.acceptAll,
+        pubData: {},
+        campaignType: CampaignType.gdpr,
+      );
+      expect(action.actionType, ActionType.acceptAll);
+      expect(action.campaignType, CampaignType.gdpr);
+      expect(action.pubData, {});
+      expect(action.customActionId, isNull);
+    });
+
+    test('creates with optional customActionId', () {
+      final action = ConsentAction(
+        actionType: ActionType.custom,
+        pubData: {'key': 'value'},
+        campaignType: CampaignType.ccpa,
+        customActionId: 'my-custom-action',
+      );
+      expect(action.customActionId, 'my-custom-action');
+      expect(action.pubData, {'key': 'value'});
+    });
+  });
+
+  group('SPError', () {
+    test('creates with required parameters', () {
+      final error = SPError(spCode: 'E_001', description: 'An error occurred');
+      expect(error.spCode, 'E_001');
+      expect(error.description, 'An error occurred');
+    });
+
+    test('toString contains key fields', () {
+      final error = SPError(spCode: 'E_001', description: 'An error occurred');
+      expect(error.toString(), contains('SPError'));
+      expect(error.toString(), contains('E_001'));
+      expect(error.toString(), contains('An error occurred'));
+    });
+  });
+
+  group('MessageLanguage enum', () {
+    test('has all expected values', () {
+      expect(MessageLanguage.values.length, 6);
+      expect(MessageLanguage.values, contains(MessageLanguage.english));
+      expect(MessageLanguage.values, contains(MessageLanguage.french));
+      expect(MessageLanguage.values, contains(MessageLanguage.german));
+      expect(MessageLanguage.values, contains(MessageLanguage.italian));
+      expect(MessageLanguage.values, contains(MessageLanguage.spanish));
+      expect(MessageLanguage.values, contains(MessageLanguage.dutch));
+    });
+  });
+
+  group('CampaignsEnv enum', () {
+    test('has all expected values', () {
+      expect(CampaignsEnv.values, contains(CampaignsEnv.stage));
+      expect(CampaignsEnv.values, contains(CampaignsEnv.public));
+    });
+  });
+
+  group('PMTab enum', () {
+    test('has all expected values', () {
+      expect(PMTab.values, contains(PMTab.purposes));
+      expect(PMTab.values, contains(PMTab.defaults));
+      expect(PMTab.values, contains(PMTab.vendors));
+      expect(PMTab.values, contains(PMTab.features));
+    });
+  });
+
+  group('CampaignType enum', () {
+    test('has all expected values', () {
+      expect(CampaignType.values.length, 7);
+      expect(CampaignType.values, contains(CampaignType.gdpr));
+      expect(CampaignType.values, contains(CampaignType.ccpa));
+      expect(CampaignType.values, contains(CampaignType.usnat));
+      expect(CampaignType.values, contains(CampaignType.ios14));
+      expect(CampaignType.values, contains(CampaignType.globalcmp));
+      expect(CampaignType.values, contains(CampaignType.preferences));
+      expect(CampaignType.values, contains(CampaignType.unknown));
+    });
+  });
+
+  group('MessageType enum', () {
+    test('has all expected values', () {
+      expect(MessageType.values, contains(MessageType.mobile));
+      expect(MessageType.values, contains(MessageType.ott));
+      expect(MessageType.values, contains(MessageType.legacyOtt));
+    });
+  });
+
+  group('GranularState enum', () {
+    test('has all expected values', () {
+      expect(GranularState.values, contains(GranularState.all));
+      expect(GranularState.values, contains(GranularState.some));
+      expect(GranularState.values, contains(GranularState.none));
+      expect(GranularState.values, contains(GranularState.emptyVl));
+    });
+  });
+
+  group('ActionType enum', () {
+    test('has all expected values', () {
+      expect(ActionType.values, contains(ActionType.showOptions));
+      expect(ActionType.values, contains(ActionType.rejectAll));
+      expect(ActionType.values, contains(ActionType.acceptAll));
+      expect(ActionType.values, contains(ActionType.msgCancel));
+      expect(ActionType.values, contains(ActionType.custom));
+      expect(ActionType.values, contains(ActionType.saveAndExit));
+      expect(ActionType.values, contains(ActionType.pmDismiss));
+      expect(ActionType.values, contains(ActionType.getMsgError));
+      expect(ActionType.values, contains(ActionType.getMessageNotCalled));
+      expect(ActionType.values, contains(ActionType.unknown));
+    });
+  });
+}

--- a/packages/sourcepoint_unified_cmp_platform_interface/test/types_test.dart
+++ b/packages/sourcepoint_unified_cmp_platform_interface/test/types_test.dart
@@ -290,12 +290,12 @@ void main() {
     test('creates with required parameters', () {
       final action = ConsentAction(
         actionType: ActionType.acceptAll,
-        pubData: {},
+        pubData: <String, Object?>{},
         campaignType: CampaignType.gdpr,
       );
       expect(action.actionType, ActionType.acceptAll);
       expect(action.campaignType, CampaignType.gdpr);
-      expect(action.pubData, {});
+      expect(action.pubData, <String, Object?>{});
       expect(action.customActionId, isNull);
     });
 


### PR DESCRIPTION
## Summary

Significantly increases the Dart/Flutter test coverage across the `sourcepoint_unified_cmp` and `sourcepoint_unified_cmp_platform_interface` packages.

**Before:** 23/92 lines covered (25.00%)
**After:** 90/92 lines covered (**97.83%**)

## New test files

### `sourcepoint_unified_cmp_platform_interface`

| File | What it covers |
|---|---|
| `test/types_test.dart` | All DTO classes (`SPConfig`, `SPConsent`, `GDPRConsent`, `CCPAConsent`, `ConsentAction`, `SPError`, `GranularStatus`, `ConsentStatus`, `GDPRPurposeGrants`) and all enums |
| `test/change_notifier_test.dart` | `ConsentChangeNotifier.updateConsent` — updates `consent` field, calls `notifyListeners`, handles multiple listeners |
| `test/interface_test.dart` | Base `SourcepointUnifiedCmpPlatform` throws `UnimplementedError` for all methods; `setInstanceUnverified`; verified `instance` setter; default `MethodChannelSourcepointUnifiedCmp` instance; `SourcepointEventDelegatePlatform` construction |
| `test/method_channel_test.dart` | `registerConsentChangeNotifier` and `registerEventDelegate` happy path and double-registration assertion errors; `loadPrivacyManager` channel dispatch |
| `test/controller_test.dart` | `AbstractSourcepointConsentController` constructor and contract via a concrete test subclass |

### `sourcepoint_unified_cmp`

| File | What it covers |
|---|---|
| `test/delegate_test.dart` | All `SourcepointEventDelegate` callback fields individually and combined |

## Extended test file

**`sourcepoint_unified_cmp/test/sourcepoint_unified_cmp_test.dart`** — new groups added:
- `SourcepointController`: `setEventDelegate`, `loadPrivacyManager` (with defaults and all optional params forwarded correctly)
- `SourcepointUnifiedCMPBuilder`: widget tests verifying the `FutureBuilder` lifecycle and that the `SPConsent` snapshot is passed to the builder callback

## What remains uncovered (2/92 lines)

The 2 uncovered lines are in `MethodChannelSourcepointUnifiedCmp.loadMessage` — that method calls `MethodChannel.invokeMethod<SPConsent>` which requires a real native platform to return a serialised `SPConsent` object. This is untestable in pure Dart unit tests and is already bypassed via mock in all consuming-package tests.